### PR TITLE
Fixed handling of unspecified IPTC fields

### DIFF
--- a/Magick.NET/Core/Profiles/Iptc/IptcProfile.cs
+++ b/Magick.NET/Core/Profiles/Iptc/IptcProfile.cs
@@ -45,7 +45,7 @@ namespace ImageMagick
 
         i++;
 
-        IptcTag tag = EnumHelper.Parse((int)Data[i++], IptcTag.Unknown);
+        IptcTag tag = (IptcTag)Data[i++];
 
         short count = ByteConverter.ToShort(Data, ref i);
 


### PR DESCRIPTION
Allows to keep IPTC fields not specified in IptcTag enum.