### PR TITLE
fixes documentation for rotate function

### DIFF
--- a/Source/Magick.NET/Core/MagickImage.cs
+++ b/Source/Magick.NET/Core/MagickImage.cs
@@ -5526,9 +5526,10 @@ namespace ImageMagick
     }
 
     /// <summary>
-    /// Rotate image counter-clockwise by specified number of degrees.
+    /// Rotate image clockwise by specified number of degrees.
     /// </summary>
-    /// <param name="degrees">The number of degrees to rotate.</param>
+    /// <remarks>Specify a negative number for <see cref="degrees"/> to rotate counter-clockwise.</remarks>
+    /// <param name="degrees">The number of degrees to rotate (positive to rotate clockwise, negative to rotate counter-clockwise).</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Rotate(double degrees)
     {

--- a/Source/Magick.NET/Core/MagickImage.cs
+++ b/Source/Magick.NET/Core/MagickImage.cs
@@ -5528,7 +5528,7 @@ namespace ImageMagick
     /// <summary>
     /// Rotate image clockwise by specified number of degrees.
     /// </summary>
-    /// <remarks>Specify a negative number for <see cref="degrees"/> to rotate counter-clockwise.</remarks>
+    /// <remarks>Specify a negative number for <paramref name="degrees"/> to rotate counter-clockwise.</remarks>
     /// <param name="degrees">The number of degrees to rotate (positive to rotate clockwise, negative to rotate counter-clockwise).</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Rotate(double degrees)


### PR DESCRIPTION
I observed that a positive value for `degrees` rotate CS, and a negative value rotates CCW.