### PR TITLE
Fix Flash ExifTagDescription for 0x4F

### DIFF
--- a/Source/Magick.NET/Shared/Profiles/Exif/ExifTag.cs
+++ b/Source/Magick.NET/Shared/Profiles/Exif/ExifTag.cs
@@ -985,7 +985,7 @@ namespace ImageMagick
         [ExifTagDescription((ushort)71, "Fired, Red-eye reduction, Return detected")]
         [ExifTagDescription((ushort)73, "On, Red-eye reduction")]
         [ExifTagDescription((ushort)77, "On, Red-eye reduction, Return not detected")]
-        [ExifTagDescription((ushort)69, "On, Red-eye reduction, Return detected")]
+        [ExifTagDescription((ushort)79, "On, Red-eye reduction, Return detected")]
         [ExifTagDescription((ushort)80, "Off, Red-eye reduction")]
         [ExifTagDescription((ushort)88, "Auto, Did not fire, Red-eye reduction")]
         [ExifTagDescription((ushort)89, "Auto, Fired, Red-eye reduction")]


### PR DESCRIPTION
The On, Red-eye reduciton, Return Detected was set to 69 = 0x45. This is
actually: Flash fired, red-eye reduction mode, return light not detected.