### PR TITLE
Assert on stream possition fixed

### DIFF
--- a/Source/Magick.NET/Shared/Helpers/Throw.cs
+++ b/Source/Magick.NET/Shared/Helpers/Throw.cs
@@ -40,7 +40,7 @@ namespace ImageMagick
         {
             IfNull(paramName, value);
 
-            if (value.CanSeek && value.Position == value.Length)
+            if (!value.CanSeek && value.Position == value.Length)
                 throw new ArgumentException("Value cannot be empty.", paramName);
         }
 


### PR DESCRIPTION
Condition that checks input stream seems to have an issue.  

`Throw.IfNullOrEmpty` was updated to fail if it's **NOT** possible rewind the stream position and the current position is at the end.

The following code fails after update from `7.0.7` to `7.4.3`
```
using (var output = new MemoryStream())
{
    using (var magickImage = new MagickImage())
    {
        magickImage.Read(pixels,
            new MagickReadSettings
            {
                PixelStorage = new PixelStorageSettings(StorageType.Char, mapping),
                Width = w,
                Height = h
            });

        magickImage.Write(output, format);
    }
    return new MagickImage(output); // exception: output is null
}
```

`pixels` is an array containing raw bitmap according to `mapping`