### PR TITLE
 change ReferenceEquals(varName, null) throughout the code. This can …

### DIFF
--- a/Source/Magick.NET/Shared/Colors/ColorBase.cs
+++ b/Source/Magick.NET/Shared/Colors/ColorBase.cs
@@ -76,8 +76,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="ColorBase"/> to compare.</param>
         public static bool operator >(ColorBase left, ColorBase right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) == 1;
         }
@@ -89,8 +89,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="ColorBase"/> to compare.</param>
         public static bool operator <(ColorBase left, ColorBase right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) == -1;
         }
@@ -102,8 +102,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="ColorBase"/> to compare.</param>
         public static bool operator >=(ColorBase left, ColorBase right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) >= 0;
         }
@@ -115,8 +115,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="ColorBase"/> to compare.</param>
         public static bool operator <=(ColorBase left, ColorBase right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) <= 0;
         }
@@ -128,7 +128,7 @@ namespace ImageMagick
         /// <returns>A signed number indicating the relative values of this instance and value.</returns>
         public int CompareTo(ColorBase other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return 1;
 
             UpdateColor();
@@ -154,7 +154,7 @@ namespace ImageMagick
         /// <returns>True when the specified color is equal to the current instance.</returns>
         public bool Equals(ColorBase other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))
@@ -174,7 +174,7 @@ namespace ImageMagick
         /// <returns>True when the specified color is fuzzy equal to the current instance.</returns>
         public bool FuzzyEquals(ColorBase other, Percentage fuzz)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/Colors/MagickColor.cs
+++ b/Source/Magick.NET/Shared/Colors/MagickColor.cs
@@ -245,8 +245,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickColor"/> to compare.</param>
         public static bool operator >(MagickColor left, MagickColor right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) == 1;
         }
@@ -258,8 +258,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickColor"/> to compare.</param>
         public static bool operator <(MagickColor left, MagickColor right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) == -1;
         }
@@ -271,8 +271,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickColor"/> to compare.</param>
         public static bool operator >=(MagickColor left, MagickColor right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) >= 0;
         }
@@ -284,8 +284,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickColor"/> to compare.</param>
         public static bool operator <=(MagickColor left, MagickColor right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) <= 0;
         }
@@ -337,7 +337,7 @@ namespace ImageMagick
         /// <returns>A signed number indicating the relative values of this instance and value.</returns>
         public int CompareTo(MagickColor other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return 1;
 
             if (R < other.R)
@@ -393,7 +393,7 @@ namespace ImageMagick
         /// <returns>True when the specified color is equal to the current color.</returns>
         public bool Equals(MagickColor other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))
@@ -416,7 +416,7 @@ namespace ImageMagick
         /// <returns>True when the specified color is fuzzy equal to the current instance.</returns>
         public bool FuzzyEquals(MagickColor other, Percentage fuzz)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/Drawables/Paths/Paths.cs
+++ b/Source/Magick.NET/Shared/Drawables/Paths/Paths.cs
@@ -44,7 +44,7 @@ namespace ImageMagick
         /// <param name="paths">The <see cref="Paths"/> to convert.</param>
         public static implicit operator Drawables(Paths paths)
         {
-            if (ReferenceEquals(paths, null))
+            if (paths is null)
                 return null;
 
             if (paths._drawables == null)

--- a/Source/Magick.NET/Shared/Helpers/Throw.cs
+++ b/Source/Magick.NET/Shared/Helpers/Throw.cs
@@ -26,7 +26,7 @@ namespace ImageMagick
 
         public static void IfNull(string paramName, object value)
         {
-            if (ReferenceEquals(value, null))
+            if (value is null)
                 throw new ArgumentNullException(paramName);
         }
 

--- a/Source/Magick.NET/Shared/MagickFormatInfo.cs
+++ b/Source/Magick.NET/Shared/MagickFormatInfo.cs
@@ -201,7 +201,7 @@ namespace ImageMagick
         /// <returns>True when the specified <see cref="MagickFormatInfo"/> is equal to the current <see cref="MagickFormatInfo"/>.</returns>
         public bool Equals(MagickFormatInfo other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/MagickImage.cs
+++ b/Source/Magick.NET/Shared/MagickImage.cs
@@ -920,8 +920,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickImage"/> to compare.</param>
         public static bool operator >(MagickImage left, MagickImage right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) == 1;
         }

--- a/Source/Magick.NET/Shared/Pixels/Pixel.cs
+++ b/Source/Magick.NET/Shared/Pixels/Pixel.cs
@@ -148,7 +148,7 @@ namespace ImageMagick
         /// <returns>True when the specified pixel is equal to the current pixel.</returns>
         public bool Equals(Pixel other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/Profiles/8Bim/EightBimValue.cs
+++ b/Source/Magick.NET/Shared/Profiles/8Bim/EightBimValue.cs
@@ -77,7 +77,7 @@ namespace ImageMagick
         /// <returns>True when the specified <see cref="EightBimValue"/> is equal to the current <see cref="EightBimValue"/>.</returns>
         public bool Equals(EightBimValue other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))
@@ -86,10 +86,10 @@ namespace ImageMagick
             if (ID != other.ID)
                 return false;
 
-            if (ReferenceEquals(_data, null))
-                return ReferenceEquals(other._data, null);
+            if (_data is null)
+                return other._data is null;
 
-            if (ReferenceEquals(other._data, null))
+            if (other._data is null)
                 return false;
 
             if (_data.Length != other._data.Length)

--- a/Source/Magick.NET/Shared/Profiles/Exif/ExifValue.cs
+++ b/Source/Magick.NET/Shared/Profiles/Exif/ExifValue.cs
@@ -165,7 +165,7 @@ namespace ImageMagick
         /// <returns>True when the specified exif value is equal to the current <see cref="ExifValue"/>.</returns>
         public bool Equals(ExifValue other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/Profiles/ImageProfile.cs
+++ b/Source/Magick.NET/Shared/Profiles/ImageProfile.cs
@@ -135,7 +135,7 @@ namespace ImageMagick
         /// <returns>True when the specified image compare is equal to the current <see cref="ImageProfile"/>.</returns>
         public bool Equals(ImageProfile other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))
@@ -146,10 +146,10 @@ namespace ImageMagick
 
             UpdateData();
 
-            if (ReferenceEquals(Data, null))
-                return ReferenceEquals(other.Data, null);
+            if (Data is null)
+                return other.Data is null;
 
-            if (ReferenceEquals(other.Data, null))
+            if (other.Data is null)
                 return false;
 
             if (Data.Length != other.Data.Length)

--- a/Source/Magick.NET/Shared/Profiles/Iptc/IptcValue.cs
+++ b/Source/Magick.NET/Shared/Profiles/Iptc/IptcValue.cs
@@ -132,7 +132,7 @@ namespace ImageMagick
         /// <returns>True when the specified iptc value is equal to the current <see cref="IptcValue"/>.</returns>
         public bool Equals(IptcValue other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))
@@ -141,10 +141,10 @@ namespace ImageMagick
             if (Tag != other.Tag)
                 return false;
 
-            if (ReferenceEquals(_data, null))
-                return ReferenceEquals(other._data, null);
+            if (_data is null)
+                return other._data is null;
 
-            if (ReferenceEquals(other._data, null))
+            if (other._data is null)
                 return false;
 
             if (_data.Length != other._data.Length)

--- a/Source/Magick.NET/Shared/Statistics/ChannelStatistics.cs
+++ b/Source/Magick.NET/Shared/Statistics/ChannelStatistics.cs
@@ -205,7 +205,7 @@ namespace ImageMagick
         /// <returns>True when the specified <see cref="ChannelStatistics"/> is equal to the current <see cref="ChannelStatistics"/>.</returns>
         public bool Equals(ChannelStatistics other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/Statistics/Statistics.cs
+++ b/Source/Magick.NET/Shared/Statistics/Statistics.cs
@@ -94,7 +94,7 @@ namespace ImageMagick
         /// <returns>True when the specified image statistics is equal to the current <see cref="Statistics"/>.</returns>
         public bool Equals(Statistics other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/Types/MagickGeometry.cs
+++ b/Source/Magick.NET/Shared/Types/MagickGeometry.cs
@@ -232,8 +232,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickGeometry"/> to compare.</param>
         public static bool operator >(MagickGeometry left, MagickGeometry right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) == 1;
         }
@@ -245,8 +245,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickGeometry"/> to compare.</param>
         public static bool operator <(MagickGeometry left, MagickGeometry right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) == -1;
         }
@@ -258,8 +258,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickGeometry"/> to compare.</param>
         public static bool operator >=(MagickGeometry left, MagickGeometry right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) >= 0;
         }
@@ -271,8 +271,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickGeometry"/> to compare.</param>
         public static bool operator <=(MagickGeometry left, MagickGeometry right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) <= 0;
         }
@@ -284,7 +284,7 @@ namespace ImageMagick
         /// <returns>A signed number indicating the relative values of this instance and value.</returns>
         public int CompareTo(MagickGeometry other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return 1;
 
             int left = Width * Height;
@@ -316,7 +316,7 @@ namespace ImageMagick
         /// <returns>True when the specified <see cref="MagickGeometry"/> is equal to the current <see cref="MagickGeometry"/>.</returns>
         public bool Equals(MagickGeometry other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/Types/Percentage.cs
+++ b/Source/Magick.NET/Shared/Types/Percentage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2018 Dirk Lemstra <https://github.com/dlemstra/Magick.NET/>
+// Copyright 2013-2018 Dirk Lemstra <https://github.com/dlemstra/Magick.NET/>
 //
 // Licensed under the ImageMagick License (the "License"); you may not use this file except in
 // compliance with the License. You may obtain a copy of the License at
@@ -113,8 +113,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator >(Percentage left, Percentage right)
         {
-            if (left is null)
-                return right is null;
+            if (ReferenceEquals(left, null))
+                return ReferenceEquals(right, null);
 
             return left.CompareTo(right) == 1;
         }
@@ -126,8 +126,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator <(Percentage left, Percentage right)
         {
-            if (left is null)
-                return !(right is null);
+            if (ReferenceEquals(left, null))
+                return !ReferenceEquals(right, null);
 
             return left.CompareTo(right) == -1;
         }
@@ -139,8 +139,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator >=(Percentage left, Percentage right)
         {
-            if (left is null)
-                return right is null;
+            if (ReferenceEquals(left, null))
+                return ReferenceEquals(right, null);
 
             return left.CompareTo(right) >= 0;
         }
@@ -152,8 +152,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator <=(Percentage left, Percentage right)
         {
-            if (left is null)
-                return !(right is null);
+            if (ReferenceEquals(left, null))
+                return !ReferenceEquals(right, null);
 
             return left.CompareTo(right) <= 0;
         }

--- a/Source/Magick.NET/Shared/Types/Percentage.cs
+++ b/Source/Magick.NET/Shared/Types/Percentage.cs
@@ -113,8 +113,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator >(Percentage left, Percentage right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) == 1;
         }
@@ -126,8 +126,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator <(Percentage left, Percentage right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) == -1;
         }
@@ -139,8 +139,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator >=(Percentage left, Percentage right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) >= 0;
         }
@@ -152,8 +152,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator <=(Percentage left, Percentage right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) <= 0;
         }

--- a/Source/Magick.NET/Shared/Types/PrimaryInfo.cs
+++ b/Source/Magick.NET/Shared/Types/PrimaryInfo.cs
@@ -73,7 +73,7 @@ namespace ImageMagick
         /// <returns>True when the specified <see cref="PrimaryInfo"/> is equal to the current <see cref="PrimaryInfo"/>.</returns>
         public bool Equals(PrimaryInfo other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))


### PR DESCRIPTION
…be replaced with varName is null.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request -->

issue #282 

<!-- Thanks for contributing to Magick.NET! -->