### PR TITLE
grammatical error in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 - Please ensure the bug was not already reported by searching our [issues](https://github.com/dlemstra/Magick.NET/issues).
 - If you're unable to find an open issue addressing the problem, please [open a new one](https://github.com/dlemstra/Magick.NET/issues/new/choose).
-  Be sure to follow follow the instructions in the issue template.
+  Be sure to follow the instructions in the issue template.
 
 #### Did you write a patch that fixes a bug?
 


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

There were two 'follow' written. Corrected that! :)