### PR TITLE
Simplify null checks

### DIFF
--- a/Source/Magick.NET.Web/Helpers/DebugThrow.cs
+++ b/Source/Magick.NET.Web/Helpers/DebugThrow.cs
@@ -34,7 +34,7 @@ namespace ImageMagick
         [Conditional("DEBUG")]
         public static void IfNull(string paramName, object value)
         {
-            if (ReferenceEquals(value, null))
+            if (value is null)
                 throw new ArgumentNullException(paramName);
         }
     }

--- a/Source/Magick.NET/Framework/Colors/MagickColor.cs
+++ b/Source/Magick.NET/Framework/Colors/MagickColor.cs
@@ -36,7 +36,7 @@ namespace ImageMagick
         /// <param name="color">The <see cref="MagickColor"/> to convert.</param>
         public static implicit operator Color(MagickColor color)
         {
-            if (ReferenceEquals(color, null))
+            if (color is null)
                 return Color.Empty;
 
             return color.ToColor();

--- a/Source/Magick.NET/Shared/MagickImage.cs
+++ b/Source/Magick.NET/Shared/MagickImage.cs
@@ -876,8 +876,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickImage"/> to compare.</param>
         public static bool operator <(MagickImage left, MagickImage right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) == -1;
         }
@@ -889,8 +889,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickImage"/> to compare.</param>
         public static bool operator >=(MagickImage left, MagickImage right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) >= 0;
         }
@@ -902,8 +902,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickImage"/> to compare.</param>
         public static bool operator <=(MagickImage left, MagickImage right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) <= 0;
         }
@@ -1880,7 +1880,7 @@ namespace ImageMagick
         /// <returns>A signed number indicating the relative values of this instance and value.</returns>
         public int CompareTo(IMagickImage other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return 1;
 
             int left = Width * Height;
@@ -2581,7 +2581,7 @@ namespace ImageMagick
         /// <returns>True when the specified <see cref="IMagickImage"/> is equal to the current <see cref="MagickImage"/>.</returns>
         public bool Equals(IMagickImage other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (Width != other.Width || Height != other.Height)

--- a/Source/Magick.NET/Shared/MagickImageInfo.cs
+++ b/Source/Magick.NET/Shared/MagickImageInfo.cs
@@ -179,8 +179,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickImageInfo"/> to compare.</param>
         public static bool operator >(MagickImageInfo left, MagickImageInfo right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) == 1;
         }
@@ -192,8 +192,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickImageInfo"/> to compare.</param>
         public static bool operator <(MagickImageInfo left, MagickImageInfo right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) == -1;
         }
@@ -205,8 +205,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickImageInfo"/> to compare.</param>
         public static bool operator >=(MagickImageInfo left, MagickImageInfo right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
+            if (left is null)
+                return right is null;
 
             return left.CompareTo(right) >= 0;
         }
@@ -218,8 +218,8 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="MagickImageInfo"/> to compare.</param>
         public static bool operator <=(MagickImageInfo left, MagickImageInfo right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
+            if (left is null)
+                return !(right is null);
 
             return left.CompareTo(right) <= 0;
         }
@@ -304,7 +304,7 @@ namespace ImageMagick
         /// <returns>A signed number indicating the relative values of this instance and value.</returns>
         public int CompareTo(IMagickImageInfo other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return 1;
 
             int left = Width * Height;

--- a/Source/Magick.NET/Shared/Types/Density.cs
+++ b/Source/Magick.NET/Shared/Types/Density.cs
@@ -141,7 +141,7 @@ namespace ImageMagick
         /// <returns>True when the specified <see cref="Density"/> is equal to the current <see cref="Density"/>.</returns>
         public bool Equals(Density other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
             if (ReferenceEquals(this, other))

--- a/Source/Magick.NET/Shared/Types/Percentage.cs
+++ b/Source/Magick.NET/Shared/Types/Percentage.cs
@@ -113,9 +113,6 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator >(Percentage left, Percentage right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
-
             return left.CompareTo(right) == 1;
         }
 
@@ -126,9 +123,6 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator <(Percentage left, Percentage right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
-
             return left.CompareTo(right) == -1;
         }
 
@@ -139,9 +133,6 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator >=(Percentage left, Percentage right)
         {
-            if (ReferenceEquals(left, null))
-                return ReferenceEquals(right, null);
-
             return left.CompareTo(right) >= 0;
         }
 
@@ -152,9 +143,6 @@ namespace ImageMagick
         /// <param name="right"> The second <see cref="Percentage"/> to compare.</param>
         public static bool operator <=(Percentage left, Percentage right)
         {
-            if (ReferenceEquals(left, null))
-                return !ReferenceEquals(right, null);
-
             return left.CompareTo(right) <= 0;
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

Simplified the rest of the ```ReferenceEquals(value, null)``` checks. Also removed null comparisons from ```Percentage``` as it will never be null.