### PR TITLE
Make exception messages for stream validation more specific

### DIFF
--- a/Source/Magick.NET/Shared/Helpers/Throw.cs
+++ b/Source/Magick.NET/Shared/Helpers/Throw.cs
@@ -40,11 +40,14 @@ namespace ImageMagick
         {
             IfNull(paramName, value);
 
-            if (value.CanSeek && value.Length == 0)
-                throw new ArgumentException("Value cannot be empty.", paramName);
+            if (value.CanSeek)
+            {
+                if (value.Length == 0)
+                    throw new ArgumentException("Value cannot be empty.", paramName);
 
-            if (value.CanSeek && value.Position == value.Length)
-                throw new ArgumentException("Stream position is at the end of the stream. Make sure to reset stream position to 0.", paramName);
+                if (value.Position == value.Length)
+                    throw new ArgumentException("Stream position is at the end of the stream. Make sure to reset stream position to 0.", paramName);
+            }
         }
 
         public static void IfNullOrEmpty(string paramName, [ValidatedNotNull] string value)

--- a/Source/Magick.NET/Shared/Helpers/Throw.cs
+++ b/Source/Magick.NET/Shared/Helpers/Throw.cs
@@ -40,8 +40,11 @@ namespace ImageMagick
         {
             IfNull(paramName, value);
 
-            if (value.CanSeek && value.Position == value.Length)
+            if (value.Length == 0)
                 throw new ArgumentException("Value cannot be empty.", paramName);
+
+            if (value.CanSeek && value.Position == value.Length)
+                throw new ArgumentException("Stream position is at the end of the stream. Make sure to reset stream position to 0.", paramName);
         }
 
         public static void IfNullOrEmpty(string paramName, [ValidatedNotNull] string value)

--- a/Source/Magick.NET/Shared/Helpers/Throw.cs
+++ b/Source/Magick.NET/Shared/Helpers/Throw.cs
@@ -40,7 +40,7 @@ namespace ImageMagick
         {
             IfNull(paramName, value);
 
-            if (value.Length == 0)
+            if (value.CanSeek && value.Length == 0)
                 throw new ArgumentException("Value cannot be empty.", paramName);
 
             if (value.CanSeek && value.Position == value.Length)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
In Throw.IfNullOrEmpty for Stream, separate the length check and the position check so that clearer feedback can be provided for both cases.

Fixes #321 