### PR TITLE
Add option to ImageOptimizer to skip compressing files in unsupported formats instead of throwing an exception

### DIFF
--- a/Source/Magick.NET/Shared/Optimizers/ImageOptimizer.cs
+++ b/Source/Magick.NET/Shared/Optimizers/ImageOptimizer.cs
@@ -35,6 +35,15 @@ namespace ImageMagick
             set;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip unsupported files instead of throwing an exception.
+        /// </summary>
+        public bool IgnoreUnsupportedFormats
+        {
+            get;
+            set;
+        }
+
         private string SupportedFormats
         {
             get
@@ -252,7 +261,10 @@ namespace ImageMagick
                     return optimizer;
             }
 
-            throw new MagickCorruptImageErrorException("Invalid format, supported formats are: " + SupportedFormats);
+            if (IgnoreUnsupportedFormats)
+                return null;
+            else
+                throw new MagickCorruptImageErrorException("Invalid format, supported formats are: " + SupportedFormats);
         }
 
         private IImageOptimizer GetOptimizer(Stream stream)
@@ -269,7 +281,10 @@ namespace ImageMagick
                     return optimizer;
             }
 
-            throw new MagickCorruptImageErrorException("Invalid format, supported formats are: " + SupportedFormats);
+            if (IgnoreUnsupportedFormats)
+                return null;
+            else
+                throw new MagickCorruptImageErrorException("Invalid format, supported formats are: " + SupportedFormats);
         }
     }
 }

--- a/Source/Magick.NET/Shared/Optimizers/ImageOptimizer.cs
+++ b/Source/Magick.NET/Shared/Optimizers/ImageOptimizer.cs
@@ -25,20 +25,20 @@ namespace ImageMagick
         private readonly Collection<IImageOptimizer> _optimizers = CreateImageOptimizers();
 
         /// <summary>
-        /// Gets or sets a value indicating whether various compression types will be used to find
-        /// the smallest file. This process will take extra time because the file has to be written
-        /// multiple times.
+        /// Gets or sets a value indicating whether to skip unsupported files instead of throwing an exception.
         /// </summary>
-        public bool OptimalCompression
+        public bool IgnoreUnsupportedFormats
         {
             get;
             set;
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to skip unsupported files instead of throwing an exception.
+        /// Gets or sets a value indicating whether various compression types will be used to find
+        /// the smallest file. This process will take extra time because the file has to be written
+        /// multiple times.
         /// </summary>
-        public bool IgnoreUnsupportedFormats
+        public bool OptimalCompression
         {
             get;
             set;
@@ -263,8 +263,8 @@ namespace ImageMagick
 
             if (IgnoreUnsupportedFormats)
                 return null;
-            else
-                throw new MagickCorruptImageErrorException("Invalid format, supported formats are: " + SupportedFormats);
+
+            throw new MagickCorruptImageErrorException("Invalid format, supported formats are: " + SupportedFormats);
         }
 
         private IImageOptimizer GetOptimizer(Stream stream)
@@ -283,8 +283,8 @@ namespace ImageMagick
 
             if (IgnoreUnsupportedFormats)
                 return null;
-            else
-                throw new MagickCorruptImageErrorException("Invalid format, supported formats are: " + SupportedFormats);
+
+            throw new MagickCorruptImageErrorException("Invalid format, supported formats are: " + SupportedFormats);
         }
     }
 }

--- a/Tests/Magick.NET.Tests/Shared/Optimizers/ImageOptimizerTests.cs
+++ b/Tests/Magick.NET.Tests/Shared/Optimizers/ImageOptimizerTests.cs
@@ -449,6 +449,23 @@ namespace Magick.NET.Tests
         }
 
         [TestMethod]
+        public void Compress_IgnoreUnsupportedFile_DoesNotThrowException()
+        {
+            var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
+            Assert.IsFalse(optimizer.Compress(Files.InvitationTif));
+        }
+
+        [TestMethod]
+        public void Compress_IgnoreUnsupportedStream_DoesNotThrowException()
+        {
+            var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
+            using (FileStream fileStream = OpenFile(Files.InvitationTif))
+            {
+                Assert.IsFalse(optimizer.Compress(fileStream));
+            }
+        }
+
+        [TestMethod]
         public void LosslessCompress_CanCompressGifFile_FileIsSmaller()
         {
             AssertCompress(Files.FujiFilmFinePixS1ProGIF, true, (FileInfo file) =>
@@ -500,6 +517,23 @@ namespace Magick.NET.Tests
             {
                 return Optimizer.LosslessCompress(file);
             });
+        }
+
+        [TestMethod]
+        public void LosslessCompress_IgnoreUnsupportedFile_DoesNotThrowException()
+        {
+            var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
+            Assert.IsFalse(optimizer.LosslessCompress(Files.InvitationTif));
+        }
+
+        [TestMethod]
+        public void LosslessCompress_IgnoreUnsupportedStream_DoesNotThrowException()
+        {
+            var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
+            using (FileStream fileStream = OpenFile(Files.InvitationTif))
+            {
+                Assert.IsFalse(optimizer.LosslessCompress(fileStream));
+            }
         }
 
         private static FileStream OpenFile(string path)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Add a `IgnoreUnsupportedFormats` option to ImageOptimizer, which when set to true causes the compression methods to return false (indicating compression failed) for unsupported files, instead of throwing an exception.

Fixes #269 