### PR TITLE
Refactor ImageOptimizer tests to follow new unit test structure

### DIFF
--- a/Tests/Magick.NET.Tests/Shared/Optimizers/ImageOptimizerTestHelper.cs
+++ b/Tests/Magick.NET.Tests/Shared/Optimizers/ImageOptimizerTestHelper.cs
@@ -16,9 +16,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Magick.NET.Tests
 {
-    public abstract class ImageOptimizerTestHelper
+    public static class ImageOptimizerTestHelper
     {
-        protected long AssertCompress(string fileName, bool resultIsSmaller, Func<FileInfo, bool> action)
+        public static long AssertCompress(string fileName, bool resultIsSmaller, Func<FileInfo, bool> action)
         {
             using (TemporaryFile tempFile = new TemporaryFile(fileName))
             {
@@ -39,7 +39,7 @@ namespace Magick.NET.Tests
             }
         }
 
-        protected long AssertCompress(string fileName, bool resultIsSmaller, Func<string, bool> action)
+        public static long AssertCompress(string fileName, bool resultIsSmaller, Func<string, bool> action)
         {
             using (TemporaryFile tempFile = new TemporaryFile(fileName))
             {
@@ -61,7 +61,7 @@ namespace Magick.NET.Tests
             }
         }
 
-        protected long AssertCompress(string fileName, bool resultIsSmaller, Func<Stream, bool> action)
+        public static long AssertCompress(string fileName, bool resultIsSmaller, Func<Stream, bool> action)
         {
             using (FileStream fileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite))
             {

--- a/Tests/Magick.NET.Tests/Shared/Optimizers/ImageOptimizerTests.cs
+++ b/Tests/Magick.NET.Tests/Shared/Optimizers/ImageOptimizerTests.cs
@@ -16,529 +16,632 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Magick.NET.Tests
 {
-    [TestClass]
-    public class ImageOptimizerTests : ImageOptimizerTestHelper
+    public partial class ImageOptimizerTests
     {
-        private ImageOptimizer Optimizer => new ImageOptimizer();
-
-        [TestMethod]
-        public void Compress_FileIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("file", () =>
-            {
-                Optimizer.Compress((FileInfo)null);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_FileNameIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
-            {
-                Optimizer.Compress((string)null);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_FileNameIsEmpty_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentException("fileName", () =>
-            {
-                Optimizer.Compress(string.Empty);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_FileNameIsInvalid_ThrowsException()
-        {
-            ExceptionAssert.Throws<MagickBlobErrorException>(() =>
-            {
-                Optimizer.Compress(Files.Missing);
-            }, "error/blob.c/OpenBlob");
-        }
-
-        [TestMethod]
-        public void Compress_InvalidFile_ThrowsException()
-        {
-            ExceptionAssert.Throws<MagickCorruptImageErrorException>(() =>
-            {
-                Optimizer.Compress(Files.InvitationTif);
-            }, "Invalid format");
-        }
-
-        [TestMethod]
-        public void Compress_EmptyFile_ThrowsException()
-        {
-            using (TemporaryFile file = new TemporaryFile("empty"))
-            {
-                ExceptionAssert.Throws<MagickMissingDelegateErrorException>(() =>
-                {
-                    Optimizer.Compress(file);
-                });
-            }
-        }
-
-        [TestMethod]
-        public void Compress_StreamIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("stream", () =>
-            {
-                Optimizer.Compress((Stream)null);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_StreamCannotRead_ThrowsException()
-        {
-            using (TestStream stream = new TestStream(false, true, true))
-            {
-                ExceptionAssert.ThrowsArgumentException("stream", () =>
-                {
-                    Optimizer.Compress(stream);
-                });
-            }
-        }
-
-        [TestMethod]
-        public void Compress_StreamCannotWrite_ThrowsException()
-        {
-            using (TestStream stream = new TestStream(true, false, true))
-            {
-                ExceptionAssert.ThrowsArgumentException("stream", () =>
-                {
-                    Optimizer.Compress(stream);
-                });
-            }
-        }
-
-        [TestMethod]
-        public void Compress_StreamCannotSeek_ThrowsException()
-        {
-            using (TestStream stream = new TestStream(true, true, false))
-            {
-                ExceptionAssert.ThrowsArgumentException("stream", () =>
-                {
-                    Optimizer.Compress(stream);
-                });
-            }
-        }
-
-        [TestMethod]
-        public void LosslessCompress_FileIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("file", () =>
-            {
-                Optimizer.LosslessCompress((FileInfo)null);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_FileNameIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
-            {
-                Optimizer.LosslessCompress((string)null);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_FileNameIsEmpty_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentException("fileName", () =>
-            {
-                Optimizer.LosslessCompress(string.Empty);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_FileNameIsInvalid_ThrowsException()
-        {
-            ExceptionAssert.Throws<MagickBlobErrorException>(() =>
-            {
-                Optimizer.LosslessCompress(Files.Missing);
-            }, "error/blob.c/OpenBlob");
-        }
-
-        [TestMethod]
-        public void LosslessCompress_InvalidFile_ThrowsException()
-        {
-            ExceptionAssert.Throws<MagickCorruptImageErrorException>(() =>
-            {
-                Optimizer.LosslessCompress(Files.InvitationTif);
-            }, "Invalid format");
-        }
-
-        [TestMethod]
-        public void LosslessCompress_EmptyFile_ThrowsException()
-        {
-            using (TemporaryFile file = new TemporaryFile("empty"))
-            {
-                ExceptionAssert.Throws<MagickMissingDelegateErrorException>(() =>
-                {
-                    Optimizer.LosslessCompress(file);
-                });
-            }
-        }
-
-        [TestMethod]
-        public void LosslessCompress_StreamIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("stream", () =>
-            {
-                Optimizer.LosslessCompress((Stream)null);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_StreamCannotRead_ThrowsException()
-        {
-            using (TestStream stream = new TestStream(false, true, true))
-            {
-                ExceptionAssert.ThrowsArgumentException("stream", () =>
-                {
-                    Optimizer.LosslessCompress(stream);
-                });
-            }
-        }
-
-        [TestMethod]
-        public void LosslessCompress_StreamCannotWrite_ThrowsException()
-        {
-            using (TestStream stream = new TestStream(true, false, true))
-            {
-                ExceptionAssert.ThrowsArgumentException("stream", () =>
-                {
-                    Optimizer.LosslessCompress(stream);
-                });
-            }
-        }
-
-        [TestMethod]
-        public void LosslessCompress_StreamCannotSeek_ThrowsException()
-        {
-            using (TestStream stream = new TestStream(true, true, false))
-            {
-                ExceptionAssert.ThrowsArgumentException("stream", () =>
-                {
-                    Optimizer.LosslessCompress(stream);
-                });
-            }
-        }
-
-        [TestMethod]
-        public void IsSupported_FileIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("file", () =>
-            {
-                Optimizer.IsSupported((FileInfo)null);
-            });
-        }
-
-        [TestMethod]
-        public void IsSupported_FileNameIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
-            {
-                Optimizer.IsSupported((string)null);
-            });
-        }
-
-        [TestMethod]
-        public void IsSupported_FileNameIsEmpty_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentException("fileName", () =>
-            {
-                Optimizer.IsSupported(string.Empty);
-            });
-        }
-
-        [TestMethod]
-        public void IsSupported_FileNameIsInvalid_ReturnsFalse()
-        {
-            Assert.IsFalse(Optimizer.IsSupported("invalid"));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileIsMissingPngFile_ReturnsTrue()
-        {
-            Assert.IsTrue(Optimizer.IsSupported(new FileInfo(Files.Missing)));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileIsGifFile_ReturnsTrue()
-        {
-            Assert.IsTrue(Optimizer.IsSupported(new FileInfo(Files.FujiFilmFinePixS1ProGIF)));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileIsJpgFile_ReturnsTrue()
-        {
-            Assert.IsTrue(Optimizer.IsSupported(new FileInfo(Files.ImageMagickJPG)));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileIsPngFile_ReturnsTrue()
-        {
-            Assert.IsTrue(Optimizer.IsSupported(new FileInfo(Files.SnakewarePNG)));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileIsTifFile_ReturnsFalse()
-        {
-            Assert.IsFalse(Optimizer.IsSupported(new FileInfo(Files.InvitationTif)));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileNameIsMissingPngFile_ReturnsTrue()
-        {
-            Assert.IsTrue(Optimizer.IsSupported(Files.Missing));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileNameIsGifFile_ReturnsTrue()
-        {
-            Assert.IsTrue(Optimizer.IsSupported(Files.FujiFilmFinePixS1ProGIF));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileNameIsJpgFile_ReturnsTrue()
-        {
-            Assert.IsTrue(Optimizer.IsSupported(Files.ImageMagickJPG));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileNameIsPngFile_ReturnsTrue()
-        {
-            Assert.IsTrue(Optimizer.IsSupported(Files.SnakewarePNG));
-        }
-
-        [TestMethod]
-        public void IsSupported_FileNameIsTifFile_ReturnsFalse()
-        {
-            Assert.IsFalse(Optimizer.IsSupported(Files.InvitationTif));
-        }
-
-        [TestMethod]
-        public void IsSupported_StreamIsNull_ThrowsException()
-        {
-            ExceptionAssert.ThrowsArgumentNullException("stream", () =>
-            {
-                Optimizer.IsSupported((Stream)null);
-            });
-        }
-
-        [TestMethod]
-        public void IsSupported_StreamCannotRead_ReturnsFalse()
-        {
-            using (TestStream stream = new TestStream(false, true, true))
-            {
-                Assert.IsFalse(Optimizer.IsSupported(stream));
-            }
-        }
-
-        [TestMethod]
-        public void IsSupported_StreamCannotWrite_ReturnsFalse()
-        {
-            using (TestStream stream = new TestStream(true, false, true))
-            {
-                Assert.IsFalse(Optimizer.IsSupported(stream));
-            }
-        }
-
-        [TestMethod]
-        public void IsSupported_StreamCannotSeek_ReturnsFalse()
-        {
-            using (TestStream stream = new TestStream(true, true, false))
-            {
-                Assert.IsFalse(Optimizer.IsSupported(stream));
-            }
-        }
-
-        [TestMethod]
-        public void IsSupported_StreamIsGifFile_ReturnsTrue()
-        {
-            using (FileStream fileStream = OpenFile(Files.FujiFilmFinePixS1ProGIF))
-            {
-                Assert.IsTrue(Optimizer.IsSupported(fileStream));
-                Assert.AreEqual(0, fileStream.Position);
-            }
-        }
-
-        [TestMethod]
-        public void IsSupported_StreamIsJpgFile_ReturnsTrue()
-        {
-            using (FileStream fileStream = OpenFile(Files.ImageMagickJPG))
-            {
-                Assert.IsTrue(Optimizer.IsSupported(fileStream));
-                Assert.AreEqual(0, fileStream.Position);
-            }
-        }
-
-        [TestMethod]
-        public void IsSupported_StreamIsPngFile_ReturnsTrue()
-        {
-            using (FileStream fileStream = OpenFile(Files.SnakewarePNG))
-            {
-                Assert.IsTrue(Optimizer.IsSupported(fileStream));
-                Assert.AreEqual(0, fileStream.Position);
-            }
-        }
-
-        [TestMethod]
-        public void IsSupported_StreamIsTifFile_ReturnsFalse()
-        {
-            using (FileStream fileStream = OpenFile(Files.InvitationTif))
-            {
-                Assert.IsFalse(Optimizer.IsSupported(fileStream));
-                Assert.AreEqual(0, fileStream.Position);
-            }
-        }
-
-        [TestMethod]
-        public void Compress_CanCompressGifFile_FileIsSmaller()
-        {
-            AssertCompress(Files.FujiFilmFinePixS1ProGIF, true, (string file) =>
-            {
-                return Optimizer.Compress(file);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_CanCompressJpgFile_FileIsSmaller()
-        {
-            AssertCompress(Files.ImageMagickJPG, true, (FileInfo file) =>
-            {
-                return Optimizer.Compress(file);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_CanCompressPngFile_FileIsSmaller()
-        {
-            AssertCompress(Files.SnakewarePNG, true, (Stream file) =>
-            {
-                return Optimizer.Compress(file);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_CannotCompressGifFile_FileNotIsSmaller()
-        {
-            AssertCompress(Files.RoseSparkleGIF, false, (Stream file) =>
-            {
-                return Optimizer.Compress(file);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_CannotCompressJpgFile_FileIsNotSmaller()
-        {
-            AssertCompress(Files.LetterJPG, false, (FileInfo file) =>
-            {
-                return Optimizer.Compress(file);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_CannotCompressPngFile_FileIsNotSmaller()
-        {
-            AssertCompress(Files.MagickNETIconPNG, false, (string file) =>
-            {
-                return Optimizer.Compress(file);
-            });
-        }
-
-        [TestMethod]
-        public void Compress_IgnoreUnsupportedFile_DoesNotThrowException()
-        {
-            var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
-            Assert.IsFalse(optimizer.Compress(Files.InvitationTif));
-        }
-
-        [TestMethod]
-        public void Compress_IgnoreUnsupportedStream_DoesNotThrowException()
-        {
-            var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
-            using (FileStream fileStream = OpenFile(Files.InvitationTif))
-            {
-                Assert.IsFalse(optimizer.Compress(fileStream));
-            }
-        }
-
-        [TestMethod]
-        public void LosslessCompress_CanCompressGifFile_FileIsSmaller()
-        {
-            AssertCompress(Files.FujiFilmFinePixS1ProGIF, true, (FileInfo file) =>
-            {
-                return Optimizer.LosslessCompress(file);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_CanCompressJpgFile_FileIsSmaller()
-        {
-            AssertCompress(Files.ImageMagickJPG, true, (string file) =>
-            {
-                return Optimizer.LosslessCompress(file);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_CanCompressPngFile_FileIsSmaller()
-        {
-            AssertCompress(Files.SnakewarePNG, true, (Stream file) =>
-            {
-                return Optimizer.LosslessCompress(file);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_CannotCompressGifFile_FileNotIsSmaller()
-        {
-            AssertCompress(Files.RoseSparkleGIF, false, (FileInfo file) =>
-            {
-                return Optimizer.LosslessCompress(file);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_CannotCompressJpgFile_FileIsNotSmaller()
-        {
-            AssertCompress(Files.LetterJPG, false, (Stream file) =>
-            {
-                return Optimizer.LosslessCompress(file);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_CannotCompressPngFile_FileIsNotSmaller()
-        {
-            AssertCompress(Files.MagickNETIconPNG, false, (string file) =>
-            {
-                return Optimizer.LosslessCompress(file);
-            });
-        }
-
-        [TestMethod]
-        public void LosslessCompress_IgnoreUnsupportedFile_DoesNotThrowException()
-        {
-            var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
-            Assert.IsFalse(optimizer.LosslessCompress(Files.InvitationTif));
-        }
-
-        [TestMethod]
-        public void LosslessCompress_IgnoreUnsupportedStream_DoesNotThrowException()
-        {
-            var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
-            using (FileStream fileStream = OpenFile(Files.InvitationTif))
-            {
-                Assert.IsFalse(optimizer.LosslessCompress(fileStream));
-            }
-        }
-
         private static FileStream OpenFile(string path)
         {
             return File.Open(path, FileMode.Open, FileAccess.ReadWrite);
+        }
+
+        [TestClass]
+        public class TheCompressMethod
+        {
+            [TestClass]
+            public class WithFile
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("file", () =>
+                    {
+                        optimizer.Compress((FileInfo)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileIsEmpty()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TemporaryFile file = new TemporaryFile("empty"))
+                    {
+                        ExceptionAssert.Throws<MagickMissingDelegateErrorException>(() =>
+                        {
+                            optimizer.Compress(file);
+                        });
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldMakeFileSmallerWhenFileIsCompressibleJpgFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.ImageMagickJPG, true, (FileInfo file) =>
+                    {
+                        return optimizer.Compress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotMakeFileSmallerWhenFileIsUncompressibleJpgFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.LetterJPG, false, (FileInfo file) =>
+                    {
+                        return optimizer.Compress(file);
+                    });
+                }
+            }
+
+            [TestClass]
+            public class WithFileName
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileNameIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
+                    {
+                        optimizer.Compress((string)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileNameIsEmpty()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
+                    {
+                        optimizer.Compress(string.Empty);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileNameIsInvalid()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.Throws<MagickBlobErrorException>(() =>
+                    {
+                        optimizer.Compress(Files.Missing);
+                    }, "error/blob.c/OpenBlob");
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileIsUnsupportedFormat()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.Throws<MagickCorruptImageErrorException>(() =>
+                    {
+                        optimizer.Compress(Files.InvitationTif);
+                    }, "Invalid format");
+                }
+
+                [TestMethod]
+                public void ShouldMakeFileSmallerWhenFileNameIsCompressibleGifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.FujiFilmFinePixS1ProGIF, true, (string file) =>
+                    {
+                        return optimizer.Compress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotMakeFileSmallerWhenFileNameIsUncompressiblePngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.MagickNETIconPNG, false, (string file) =>
+                    {
+                        return optimizer.Compress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotThrowExceptionWhenIgnoringUnsupportedFileName()
+                {
+                    var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
+                    var compressionSuccess = optimizer.Compress(Files.InvitationTif);
+                    Assert.IsFalse(compressionSuccess);
+                }
+            }
+
+            [TestClass]
+            public class WithStream
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("stream", () =>
+                    {
+                        optimizer.Compress((Stream)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamCannotRead()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(false, true, true))
+                    {
+                        ExceptionAssert.ThrowsArgumentException("stream", () =>
+                        {
+                            optimizer.Compress(stream);
+                        });
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamCannotWrite()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(true, false, true))
+                    {
+                        ExceptionAssert.ThrowsArgumentException("stream", () =>
+                        {
+                            optimizer.Compress(stream);
+                        });
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamCannotSeek()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(true, true, false))
+                    {
+                        ExceptionAssert.ThrowsArgumentException("stream", () =>
+                        {
+                            optimizer.Compress(stream);
+                        });
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldMakeFileSmallerWhenStreamIsCompressiblePngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.SnakewarePNG, true, (Stream file) =>
+                    {
+                        return optimizer.Compress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotMakeFileSmallerWhenStreamIsUncompressibleGifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.RoseSparkleGIF, false, (Stream file) =>
+                    {
+                        return optimizer.Compress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotThrowExceptionWhenIgnoringUnsupportedStream()
+                {
+                    var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
+                    using (FileStream fileStream = OpenFile(Files.InvitationTif))
+                    {
+                        var compressionSuccess = optimizer.Compress(fileStream);
+                        Assert.IsFalse(compressionSuccess);
+                    }
+                }
+            }
+        }
+
+        [TestClass]
+        public class TheLosslessCompressMethod
+        {
+            [TestClass]
+            public class WithFile
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("file", () =>
+                    {
+                        optimizer.LosslessCompress((FileInfo)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileIsEmpty()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TemporaryFile file = new TemporaryFile("empty"))
+                    {
+                        ExceptionAssert.Throws<MagickMissingDelegateErrorException>(() =>
+                        {
+                            optimizer.LosslessCompress(file);
+                        });
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldMakeFileSmallerWhenFileIsCompressibleGifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.FujiFilmFinePixS1ProGIF, true, (FileInfo file) =>
+                    {
+                        return optimizer.LosslessCompress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotMakeFileSmallerWhenFileIsUnCompressibleGifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.RoseSparkleGIF, false, (FileInfo file) =>
+                    {
+                        return optimizer.LosslessCompress(file);
+                    });
+                }
+            }
+
+            [TestClass]
+            public class WithFileName
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileNameIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
+                    {
+                        optimizer.LosslessCompress((string)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileNameIsEmpty()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
+                    {
+                        optimizer.LosslessCompress(string.Empty);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileNameIsInvalid()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.Throws<MagickBlobErrorException>(() =>
+                    {
+                        optimizer.LosslessCompress(Files.Missing);
+                    }, "error/blob.c/OpenBlob");
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileIsUnsupportedFormat()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.Throws<MagickCorruptImageErrorException>(() =>
+                    {
+                        optimizer.LosslessCompress(Files.InvitationTif);
+                    }, "Invalid format");
+                }
+
+                [TestMethod]
+                public void ShouldMakeFileSmallerWhenFileNameIsCompressibleJpgFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.ImageMagickJPG, true, (string file) =>
+                    {
+                        return optimizer.LosslessCompress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotMakeFileSmallerWhenFileNameIsUncompressiblePngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.MagickNETIconPNG, false, (string file) =>
+                    {
+                        return optimizer.LosslessCompress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotThrowExceptionWhenIgnoringUnsupportedFileName()
+                {
+                    var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
+                    var compressionSuccess = optimizer.LosslessCompress(Files.InvitationTif);
+                    Assert.IsFalse(compressionSuccess);
+                }
+            }
+
+            [TestClass]
+            public class WithStream
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("stream", () =>
+                    {
+                        optimizer.LosslessCompress((Stream)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamCannotRead()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(false, true, true))
+                    {
+                        ExceptionAssert.ThrowsArgumentException("stream", () =>
+                        {
+                            optimizer.LosslessCompress(stream);
+                        });
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamCannotWrite()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(true, false, true))
+                    {
+                        ExceptionAssert.ThrowsArgumentException("stream", () =>
+                        {
+                            optimizer.LosslessCompress(stream);
+                        });
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamCannotSeek()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(true, true, false))
+                    {
+                        ExceptionAssert.ThrowsArgumentException("stream", () =>
+                        {
+                            optimizer.LosslessCompress(stream);
+                        });
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldMakeFileSmallerWhenStreamIsCompressiblePngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.SnakewarePNG, true, (Stream file) =>
+                    {
+                        return optimizer.LosslessCompress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotMakeFileSmallerWhenStreamIsCompressibleJpgFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ImageOptimizerTestHelper.AssertCompress(Files.LetterJPG, false, (Stream file) =>
+                    {
+                        return optimizer.LosslessCompress(file);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldNotThrowExceptionWhenIgnoringUnsupportedStream()
+                {
+                    var optimizer = new ImageOptimizer { IgnoreUnsupportedFormats = true };
+                    using (FileStream fileStream = OpenFile(Files.InvitationTif))
+                    {
+                        var compressionSuccess = optimizer.LosslessCompress(fileStream);
+                        Assert.IsFalse(compressionSuccess);
+                    }
+                }
+            }
+        }
+
+        [TestClass]
+        public class TheIsSupportedMethod
+        {
+            [TestClass]
+            public class WithFile
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("file", () =>
+                    {
+                        optimizer.IsSupported((FileInfo)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenFileIsMissingPngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(new FileInfo(Files.Missing)));
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenFileIsFileIsGifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(new FileInfo(Files.FujiFilmFinePixS1ProGIF)));
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenFileIsFileIsJpgFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(new FileInfo(Files.ImageMagickJPG)));
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenFileIsFileIsPngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(new FileInfo(Files.SnakewarePNG)));
+                }
+
+                [TestMethod]
+                public void ShouldReturnFalseWhenFileIsFileIsTifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsFalse(optimizer.IsSupported(new FileInfo(Files.InvitationTif)));
+                }
+            }
+
+            [TestClass]
+            public class WithFileName
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileNameIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
+                    {
+                        optimizer.IsSupported((string)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldThrowExceptionWhenFileNameIsEmpty()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("fileName", () =>
+                    {
+                        optimizer.IsSupported(string.Empty);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldReturnFalseWhenFileNameIsInvalid()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsFalse(optimizer.IsSupported("invalid"));
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenFileNameIsMissingPngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(Files.Missing));
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenFileNameIsGifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(Files.FujiFilmFinePixS1ProGIF));
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenFileNameIsJpgFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(Files.ImageMagickJPG));
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenFileNameIsPngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(Files.SnakewarePNG));
+                }
+
+                [TestMethod]
+                public void ShouldReturnFalseWhenFileNameIsTifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    Assert.IsTrue(optimizer.IsSupported(Files.InvitationTif));
+                }
+            }
+
+            [TestClass]
+            public class WithStream
+            {
+                [TestMethod]
+                public void ShouldThrowExceptionWhenStreamIsNull()
+                {
+                    var optimizer = new ImageOptimizer();
+                    ExceptionAssert.ThrowsArgumentNullException("stream", () =>
+                    {
+                        optimizer.IsSupported((Stream)null);
+                    });
+                }
+
+                [TestMethod]
+                public void ShouldReturnFalseWhenStreamCannotRead()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(false, true, true))
+                    {
+                        Assert.IsFalse(optimizer.IsSupported(stream));
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldReturnFalseWhenStreamCannotWrite()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(true, false, true))
+                    {
+                        Assert.IsFalse(optimizer.IsSupported(stream));
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldReturnFalseWhenStreamCannotSeek()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (TestStream stream = new TestStream(true, true, false))
+                    {
+                        Assert.IsFalse(optimizer.IsSupported(stream));
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenStreamIsGifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (FileStream fileStream = OpenFile(Files.FujiFilmFinePixS1ProGIF))
+                    {
+                        Assert.IsTrue(optimizer.IsSupported(fileStream));
+                        Assert.AreEqual(0, fileStream.Position);
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenStreamIsJpgFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (FileStream fileStream = OpenFile(Files.ImageMagickJPG))
+                    {
+                        Assert.IsTrue(optimizer.IsSupported(fileStream));
+                        Assert.AreEqual(0, fileStream.Position);
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldReturnTrueWhenStreamIsPngFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (FileStream fileStream = OpenFile(Files.SnakewarePNG))
+                    {
+                        Assert.IsTrue(optimizer.IsSupported(fileStream));
+                        Assert.AreEqual(0, fileStream.Position);
+                    }
+                }
+
+                [TestMethod]
+                public void ShouldReturnFalseWhenStreamIsTifFile()
+                {
+                    var optimizer = new ImageOptimizer();
+                    using (FileStream fileStream = OpenFile(Files.InvitationTif))
+                    {
+                        Assert.IsFalse(optimizer.IsSupported(fileStream));
+                        Assert.AreEqual(0, fileStream.Position);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
Renamed and reorganized all ImageOptimizer tests to follow the pattern demonstrated in [this file](https://github.com/dlemstra/line-bot-sdk-dotnet/blob/master/tests/LineBot.Tests/LineBotTests/TheSetDefaultRichMenuMethod.cs). To achieve the new structure I also changed ImageOptimizerTestHelper to be static since there is no longer just one test class that can inherit it.