### PR TITLE
Add Dencity to return value ToBitmapSource()

### DIFF
--- a/Source/Magick.NET/Framework/MagickImage.cs
+++ b/Source/Magick.NET/Framework/MagickImage.cs
@@ -179,7 +179,15 @@ namespace ImageMagick
                 using (IPixelCollection pixels = image.GetPixelsUnsafe())
                 {
                     byte[] bytes = pixels.ToByteArray(mapping);
-                    return BitmapSource.Create(Width, Height, 96, 96, format, null, bytes, stride);
+                    switch(Density.Units)
+                    {
+                        case DensityUnit.PixelsPerCentimeter:
+                            return BitmapSource.Create(Width, Height, Math.Round(Density.X*2.54), Math.Round(Density.Y*2.54), format, null, bytes, stride);
+                        case DensityUnit.PixelsPerInch:
+                            return BitmapSource.Create(Width, Height, Density.X, Density.Y, format, null, bytes, stride);
+                        default:
+                            return BitmapSource.Create(Width, Height, 96, 96, format, null, bytes, stride);
+                    }
                 }
             }
             finally


### PR DESCRIPTION
I work with scanned images. MagickImage loads right dencity of images. But when I convert them to bitmapsource, dencity changes to standard value - 96.
I made some changes to produce right dencity.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request -->
ToBitmapSource() method returns BitmapSource with right dencity of original image.
<!-- Thanks for contributing to Magick.NET! -->