### PR TITLE
Add the possibility to add some IPTC values with the same tag more than once

### DIFF
--- a/src/Magick.NET/Shared/Defines/ProfileTypes.cs
+++ b/src/Magick.NET/Shared/Defines/ProfileTypes.cs
@@ -46,7 +46,7 @@ namespace ImageMagick.Defines
         Iptc = 16,
 
         /// <summary>
-        /// Iptc profile
+        /// Xmp profile
         /// </summary>
         Xmp = 32,
     }

--- a/src/Magick.NET/Shared/Profiles/Iptc/IIptcProfile.cs
+++ b/src/Magick.NET/Shared/Profiles/Iptc/IIptcProfile.cs
@@ -38,7 +38,7 @@ namespace ImageMagick
         /// </summary>
         /// <param name="tag">The tag of the iptc value.</param>
         /// <returns>The values found with the specified tag.</returns>
-        List<IptcValue> GetValues(IptcTag tag);
+        List<IIptcValue> GetAllValues(IptcTag tag);
 
         /// <summary>
         /// Removes all values with the specified tag.

--- a/src/Magick.NET/Shared/Profiles/Iptc/IIptcProfile.cs
+++ b/src/Magick.NET/Shared/Profiles/Iptc/IIptcProfile.cs
@@ -10,6 +10,7 @@
 // either express or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -52,7 +53,7 @@ namespace ImageMagick
         /// <param name="tag">The tag of the iptc value to remove.</param>
         /// <param name="value">The value of the iptc item to remove.</param>
         /// <returns>True when the value was found and removed.</returns>
-        public bool RemoveValue(IptcTag tag, string value);
+        bool RemoveValue(IptcTag tag, string value);
 
         /// <summary>
         /// Changes the encoding for all the values.
@@ -74,5 +75,17 @@ namespace ImageMagick
         /// <param name="tag">The tag of the iptc value.</param>
         /// <param name="value">The value.</param>
         void SetValue(IptcTag tag, string value);
+
+        /// <summary>
+        /// Makes sure the datetime is formatted according to the iptc specification.
+        /// <example>
+        /// A date will be formatted as CCYYMMDD, e.g. "19890317" for 17 March 1989.
+        /// A time value will be formatted as HHMMSS±HHMM, e.g. "090000+0200" for 9 o'clock Berlin time,
+        /// two hours ahead of UTC.
+        /// </example>
+        /// </summary>
+        /// <param name="tag">The tag of the iptc value.</param>
+        /// <param name="dateTimeOffset">The datetime.</param>
+        void SetDateTimeValue(IptcTag tag, DateTimeOffset dateTimeOffset);
     }
 }

--- a/src/Magick.NET/Shared/Profiles/Iptc/IIptcProfile.cs
+++ b/src/Magick.NET/Shared/Profiles/Iptc/IIptcProfile.cs
@@ -26,18 +26,33 @@ namespace ImageMagick
         IEnumerable<IIptcValue> Values { get; }
 
         /// <summary>
-        /// Returns the value with the specified tag.
+        /// Returns the first occurrence of a iptc value with the specified tag.
         /// </summary>
         /// <param name="tag">The tag of the iptc value.</param>
         /// <returns>The value with the specified tag.</returns>
         IIptcValue GetValue(IptcTag tag);
 
         /// <summary>
-        /// Removes the value with the specified tag.
+        /// Returns all values with the specified tag.
         /// </summary>
         /// <param name="tag">The tag of the iptc value.</param>
-        /// <returns>True when the value was fount and removed.</returns>
+        /// <returns>The values found with the specified tag.</returns>
+        List<IptcValue> GetValues(IptcTag tag);
+
+        /// <summary>
+        /// Removes all values with the specified tag.
+        /// </summary>
+        /// <param name="tag">The tag of the iptc value to remove.</param>
+        /// <returns>True when the value was found and removed.</returns>
         bool RemoveValue(IptcTag tag);
+
+        /// <summary>
+        /// Removes values with the specified tag and value.
+        /// </summary>
+        /// <param name="tag">The tag of the iptc value to remove.</param>
+        /// <param name="value">The value of the iptc item to remove.</param>
+        /// <returns>True when the value was found and removed.</returns>
+        public bool RemoveValue(IptcTag tag, string value);
 
         /// <summary>
         /// Changes the encoding for all the values.

--- a/src/Magick.NET/Shared/Profiles/Iptc/IptcProfile.cs
+++ b/src/Magick.NET/Shared/Profiles/Iptc/IptcProfile.cs
@@ -31,6 +31,7 @@ namespace ImageMagick
         public IptcProfile()
           : base("iptc")
         {
+            Initialize();
         }
 
         /// <summary>
@@ -40,6 +41,7 @@ namespace ImageMagick
         public IptcProfile(byte[] data)
           : base("iptc", data)
         {
+            Initialize();
         }
 
         /// <summary>
@@ -50,6 +52,7 @@ namespace ImageMagick
         public IptcProfile(string fileName)
           : base("iptc", fileName)
         {
+            Initialize();
         }
 
         /// <summary>
@@ -59,6 +62,7 @@ namespace ImageMagick
         public IptcProfile(Stream stream)
           : base("iptc", stream)
         {
+            Initialize();
         }
 
         /// <summary>
@@ -74,7 +78,7 @@ namespace ImageMagick
         }
 
         /// <summary>
-        /// Returns the value with the specified tag.
+        /// Returns the first occurrence of a iptc value with the specified tag.
         /// </summary>
         /// <param name="tag">The tag of the iptc value.</param>
         /// <returns>The value with the specified tag.</returns>
@@ -90,24 +94,67 @@ namespace ImageMagick
         }
 
         /// <summary>
-        /// Removes the value with the specified tag.
+        /// Returns all values with the specified tag.
         /// </summary>
         /// <param name="tag">The tag of the iptc value.</param>
-        /// <returns>True when the value was fount and removed.</returns>
+        /// <returns>The values found with the specified tag.</returns>
+        public List<IptcValue> GetValues(IptcTag tag)
+        {
+            var iptcValues = new List<IptcValue>();
+            foreach (IptcValue iptcValue in Values)
+            {
+                if (iptcValue.Tag == tag)
+                {
+                    iptcValues.Add(iptcValue);
+                }
+            }
+
+            return iptcValues;
+        }
+
+        /// <summary>
+        /// Removes all values with the specified tag.
+        /// </summary>
+        /// <param name="tag">The tag of the iptc value to remove.</param>
+        /// <returns>True when the value was found and removed.</returns>
         public bool RemoveValue(IptcTag tag)
         {
             Initialize();
 
-            for (int i = 0; i < _values.Count; i++)
+            bool removed = false;
+            for (int i = _values.Count - 1; i >= 0; i--)
             {
                 if (_values[i].Tag == tag)
                 {
                     _values.RemoveAt(i);
-                    return true;
+                    removed = true;
                 }
             }
 
-            return false;
+            return removed;
+        }
+
+        /// <summary>
+        /// Removes values with the specified tag and value.
+        /// </summary>
+        /// <param name="tag">The tag of the iptc value to remove.</param>
+        /// <param name="value">The value of the iptc item to remove.</param>
+        /// <returns>True when the value was found and removed.</returns>
+        public bool RemoveValue(IptcTag tag, string value)
+        {
+            Initialize();
+
+            bool removed = false;
+            for (int i = _values.Count - 1; i >= 0; i--)
+            {
+                if (_values[i].Tag == tag && _values[i].Value.Equals(value, StringComparison.Ordinal))
+                {
+                    _values.RemoveAt(i);
+                    removed = true;
+                }
+            }
+
+            return removed;
         }
 
         /// <summary>
@@ -134,13 +181,16 @@ namespace ImageMagick
         {
             Throw.IfNull(nameof(encoding), encoding);
 
-            foreach (IptcValue iptcValue in Values)
+            if (!tag.IsRepeatable())
             {
-                if (iptcValue.Tag == tag)
+                foreach (IptcValue iptcValue in Values)
                 {
-                    iptcValue.Encoding = encoding;
-                    iptcValue.Value = value;
-                    return;
+                    if (iptcValue.Tag == tag)
+                    {
+                        iptcValue.Encoding = encoding;
+                        iptcValue.Value = value;
+                        return;
+                    }
                 }
             }
 

--- a/src/Magick.NET/Shared/Profiles/Iptc/IptcProfile.cs
+++ b/src/Magick.NET/Shared/Profiles/Iptc/IptcProfile.cs
@@ -205,6 +205,31 @@ namespace ImageMagick
         public void SetValue(IptcTag tag, string value) => SetValue(tag, Encoding.UTF8, value);
 
         /// <summary>
+        /// Makes sure the datetime is formatted according to the iptc specification.
+        /// <example>
+        /// A date will be formatted as CCYYMMDD, e.g. "19890317" for 17 March 1989.
+        /// A time value will be formatted as HHMMSS±HHMM, e.g. "090000+0200" for 9 o'clock Berlin time,
+        /// two hours ahead of UTC.
+        /// </example>
+        /// </summary>
+        /// <param name="tag">The tag of the iptc value.</param>
+        /// <param name="dateTimeOffset">The datetime.</param>
+        public void SetDateTimeValue(IptcTag tag, DateTimeOffset dateTimeOffset)
+        {
+            if (!tag.IsDate() && !tag.IsTime())
+            {
+                throw new ArgumentException("iptc tag is not a time or date type");
+            }
+
+            var formattedDate = tag.IsDate()
+                ? dateTimeOffset.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture)
+                : dateTimeOffset.ToString("HHmmsszzzz", System.Globalization.CultureInfo.InvariantCulture)
+                    .Replace(":", string.Empty);
+
+            SetValue(tag, Encoding.UTF8, formattedDate);
+        }
+
+        /// <summary>
         /// Updates the data of the profile.
         /// </summary>
         protected override void UpdateData()

--- a/src/Magick.NET/Shared/Profiles/Iptc/IptcProfile.cs
+++ b/src/Magick.NET/Shared/Profiles/Iptc/IptcProfile.cs
@@ -98,9 +98,9 @@ namespace ImageMagick
         /// </summary>
         /// <param name="tag">The tag of the iptc value.</param>
         /// <returns>The values found with the specified tag.</returns>
-        public List<IptcValue> GetValues(IptcTag tag)
+        public List<IIptcValue> GetAllValues(IptcTag tag)
         {
-            var iptcValues = new List<IptcValue>();
+            var iptcValues = new List<IIptcValue>();
             foreach (IptcValue iptcValue in Values)
             {
                 if (iptcValue.Tag == tag)

--- a/src/Magick.NET/Shared/Profiles/Iptc/IptcTag.cs
+++ b/src/Magick.NET/Shared/Profiles/Iptc/IptcTag.cs
@@ -58,6 +58,11 @@ namespace ImageMagick
         Priority = 10,
 
         /// <summary>
+        /// Subject Reference
+        /// </summary>
+        SubjectReference = 12,
+
+        /// <summary>
         /// Category
         /// </summary>
         Category = 15,

--- a/src/Magick.NET/Shared/Profiles/Iptc/IptcTagExtensions.cs
+++ b/src/Magick.NET/Shared/Profiles/Iptc/IptcTagExtensions.cs
@@ -1,0 +1,111 @@
+// Copyright 2013-2020 Dirk Lemstra <https://github.com/dlemstra/Magick.NET/>
+//
+// Licensed under the ImageMagick License (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+//
+//   https://www.imagemagick.org/script/license.php
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+namespace ImageMagick
+{
+    /// <summary>
+    /// Extension methods for IPTC tags.
+    /// </summary>
+    public static class IptcTagExtensions
+    {
+        /// <summary>
+        /// Determines if the given tag can be repeated according to the specification.
+        /// </summary>
+        /// <param name="tag">The tag to check.</param>
+        /// <returns>True, if the tag can occur multiple times.</returns>
+        public static bool IsRepeatable(this IptcTag tag)
+        {
+            switch (tag)
+            {
+                case IptcTag.RecordVersion:
+                case IptcTag.ObjectType:
+                case IptcTag.Title:
+                case IptcTag.EditStatus:
+                case IptcTag.EditorialUpdate:
+                case IptcTag.Priority:
+                case IptcTag.Category:
+                case IptcTag.FixtureIdentifier:
+                case IptcTag.ReleaseDate:
+                case IptcTag.ReleaseTime:
+                case IptcTag.ExpirationDate:
+                case IptcTag.ExpirationTime:
+                case IptcTag.SpecialInstructions:
+                case IptcTag.ActionAdvised:
+                case IptcTag.CreatedDate:
+                case IptcTag.CreatedTime:
+                case IptcTag.DigitalCreationDate:
+                case IptcTag.DigitalCreationTime:
+                case IptcTag.OriginatingProgram:
+                case IptcTag.ProgramVersion:
+                case IptcTag.ObjectCycle:
+                case IptcTag.City:
+                case IptcTag.SubLocation:
+                case IptcTag.ProvinceState:
+                case IptcTag.CountryCode:
+                case IptcTag.Country:
+                case IptcTag.OriginalTransmissionReference:
+                case IptcTag.Headline:
+                case IptcTag.Credit:
+                case IptcTag.Source:
+                case IptcTag.CopyrightNotice:
+                case IptcTag.Caption:
+                case IptcTag.ImageType:
+                case IptcTag.ImageOrientation:
+                    return false;
+
+                default:
+                    return true;
+            }
+        }
+
+        /// <summary>
+        /// Determines if the tag is a datetime tag which needs to be formatted as CCYYMMDD.
+        /// </summary>
+        /// <param name="tag">The tag to check.</param>
+        /// <returns>True, if its a datetime tag.</returns>
+        public static bool IsDate(this IptcTag tag)
+        {
+            switch (tag)
+            {
+                case IptcTag.CreatedDate:
+                case IptcTag.DigitalCreationDate:
+                case IptcTag.ExpirationDate:
+                case IptcTag.ReferenceDate:
+                case IptcTag.ReleaseDate:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Determines if the tag is a time tag which need to be formatted as HHMMSS±HHMM.
+        /// </summary>
+        /// <param name="tag">The tag to check.</param>
+        /// <returns>True, if its a time tag.</returns>
+        public static bool IsTime(this IptcTag tag)
+        {
+            switch (tag)
+            {
+                case IptcTag.CreatedTime:
+                case IptcTag.DigitalCreationTime:
+                case IptcTag.ExpirationTime:
+                case IptcTag.ReleaseTime:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Shared/Profiles/Iptc/IptcProfileTests.cs
+++ b/tests/Magick.NET.Tests/Shared/Profiles/Iptc/IptcProfileTests.cs
@@ -270,6 +270,46 @@ namespace Magick.NET.Tests
             Assert.AreEqual(2, result.Count);
         }
 
+        [TestMethod]
+        [DataRow(IptcTag.DigitalCreationDate)]
+        [DataRow(IptcTag.ExpirationDate)]
+        [DataRow(IptcTag.CreatedDate)]
+        [DataRow(IptcTag.ReferenceDate)]
+        [DataRow(IptcTag.ReleaseDate)]
+        public void IptcProfile_SetDateValue_Works(IptcTag tag)
+        {
+            // arrange
+            var profile = new IptcProfile();
+            var datetime = new DateTimeOffset(new DateTime(1994, 3, 17));
+
+            // act
+            profile.SetDateTimeValue(tag, datetime);
+
+            // assert
+            IptcValue actual = profile.GetValues(tag).First();
+            Assert.AreEqual("19940317", actual.Value);
+        }
+
+        [TestMethod]
+        [DataRow(IptcTag.CreatedTime)]
+        [DataRow(IptcTag.DigitalCreationTime)]
+        [DataRow(IptcTag.ExpirationTime)]
+        [DataRow(IptcTag.ReleaseTime)]
+        public void IptcProfile_SetTimeValue_Works(IptcTag tag)
+        {
+            // arrange
+            var profile = new IptcProfile();
+            var dateTimeUtc = new DateTime(1994, 3, 17, 14, 15, 16, DateTimeKind.Utc);
+            DateTimeOffset dateTimeOffset = new DateTimeOffset(dateTimeUtc).ToOffset(TimeSpan.FromHours(2));
+
+            // act
+            profile.SetDateTimeValue(tag, dateTimeOffset);
+
+            // assert
+            IptcValue actual = profile.GetValues(tag).First();
+            Assert.AreEqual("161516+0200", actual.Value);
+        }
+
         private static void ContainsIptcValue(List<IIptcValue> values, IptcTag tag, string value)
         {
             Assert.IsTrue(values.Any(val => val.Tag == tag), $"Missing iptc tag {tag}");

--- a/tests/Magick.NET.Tests/Shared/Profiles/Iptc/IptcProfileTests.cs
+++ b/tests/Magick.NET.Tests/Shared/Profiles/Iptc/IptcProfileTests.cs
@@ -11,6 +11,7 @@
 // and limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -135,6 +136,145 @@ namespace Magick.NET.Tests
                     TestProfileValues(profile);
                 }
             }
+        }
+
+        [TestMethod]
+        [DataRow(IptcTag.ObjectAttribute)]
+        [DataRow(IptcTag.SubjectReference)]
+        [DataRow(IptcTag.SupplementalCategories)]
+        [DataRow(IptcTag.Keyword)]
+        [DataRow(IptcTag.LocationCode)]
+        [DataRow(IptcTag.LocationName)]
+        [DataRow(IptcTag.ReferenceService)]
+        [DataRow(IptcTag.ReferenceDate)]
+        [DataRow(IptcTag.ReferenceNumber)]
+        [DataRow(IptcTag.Byline)]
+        [DataRow(IptcTag.BylineTitle)]
+        [DataRow(IptcTag.Contact)]
+        [DataRow(IptcTag.LocalCaption)]
+        [DataRow(IptcTag.CaptionWriter)]
+        public void Test_AddRepeatable(IptcTag tag)
+        {
+            // arrange
+            var profile = new IptcProfile();
+            var expectedValue1 = "test";
+            var expectedValue2 = "another one";
+            profile.SetValue(tag, expectedValue1);
+
+            // act
+            profile.SetValue(tag, expectedValue2);
+
+            // assert
+            var values = profile.Values.ToList();
+            Assert.AreEqual(2, values.Count);
+            ContainsIptcValue(values, tag, expectedValue1);
+            ContainsIptcValue(values, tag, expectedValue2);
+        }
+
+        [TestMethod]
+        [DataRow(IptcTag.RecordVersion)]
+        [DataRow(IptcTag.ObjectType)]
+        [DataRow(IptcTag.Title)]
+        [DataRow(IptcTag.EditStatus)]
+        [DataRow(IptcTag.EditorialUpdate)]
+        [DataRow(IptcTag.Priority)]
+        [DataRow(IptcTag.Category)]
+        [DataRow(IptcTag.FixtureIdentifier)]
+        [DataRow(IptcTag.ReleaseDate)]
+        [DataRow(IptcTag.ReleaseTime)]
+        [DataRow(IptcTag.ExpirationDate)]
+        [DataRow(IptcTag.ExpirationTime)]
+        [DataRow(IptcTag.SpecialInstructions)]
+        [DataRow(IptcTag.ActionAdvised)]
+        [DataRow(IptcTag.CreatedDate)]
+        [DataRow(IptcTag.CreatedTime)]
+        [DataRow(IptcTag.DigitalCreationDate)]
+        [DataRow(IptcTag.DigitalCreationTime)]
+        [DataRow(IptcTag.OriginatingProgram)]
+        [DataRow(IptcTag.ProgramVersion)]
+        [DataRow(IptcTag.ObjectCycle)]
+        [DataRow(IptcTag.City)]
+        [DataRow(IptcTag.SubLocation)]
+        [DataRow(IptcTag.ProvinceState)]
+        [DataRow(IptcTag.CountryCode)]
+        [DataRow(IptcTag.Country)]
+        [DataRow(IptcTag.OriginalTransmissionReference)]
+        [DataRow(IptcTag.Headline)]
+        [DataRow(IptcTag.Credit)]
+        [DataRow(IptcTag.CopyrightNotice)]
+        [DataRow(IptcTag.Caption)]
+        [DataRow(IptcTag.ImageType)]
+        [DataRow(IptcTag.ImageOrientation)]
+        public void Test_AddNoneRepeatable_DoesOverrideOldValue(IptcTag tag)
+        {
+            // arrange
+            var profile = new IptcProfile();
+            var expectedValue = "another one";
+            profile.SetValue(tag, "test");
+
+            // act
+            profile.SetValue(tag, expectedValue);
+
+            // assert
+            var values = profile.Values.ToList();
+            Assert.AreEqual(1, values.Count);
+            ContainsIptcValue(values, tag, expectedValue);
+        }
+
+        [TestMethod]
+        public void Test_RemoveByTag_RemovesAllEntries()
+        {
+            // arrange
+            var profile = new IptcProfile();
+            profile.SetValue(IptcTag.Byline, "test");
+            profile.SetValue(IptcTag.Byline, "test2");
+
+            // act
+            var result = profile.RemoveValue(IptcTag.Byline);
+
+            // assert
+            Assert.IsTrue(result, "removed result should be true");
+            Assert.AreEqual(0, profile.Values.Count());
+        }
+
+        [TestMethod]
+        public void Test_RemoveByTagAndValue_Works()
+        {
+            // arrange
+            var profile = new IptcProfile();
+            profile.SetValue(IptcTag.Byline, "test");
+            profile.SetValue(IptcTag.Byline, "test2");
+
+            // act
+            var result = profile.RemoveValue(IptcTag.Byline, "test2");
+
+            // assert
+            Assert.IsTrue(result, "removed result should be true");
+            ContainsIptcValue(profile.Values.ToList(), IptcTag.Byline, "test");
+        }
+
+        [TestMethod]
+        public void Test_GetValues_RetrievesAllEntries()
+        {
+            // arrange
+            var profile = new IptcProfile();
+            profile.SetValue(IptcTag.Byline, "test");
+            profile.SetValue(IptcTag.Byline, "test2");
+            profile.SetValue(IptcTag.Caption, "test");
+
+            // act
+            List<IptcValue> result = profile.GetValues(IptcTag.Byline);
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count);
+        }
+
+        private static void ContainsIptcValue(List<IIptcValue> values, IptcTag tag, string value)
+        {
+            Assert.IsTrue(values.Any(val => val.Tag == tag), $"Missing iptc tag {tag}");
+            Assert.IsTrue(values.Contains(new IptcValue(tag, Encoding.UTF8.GetBytes(value))),
+                $"expected iptc value '{value}' was not found for tag '{tag}'");
         }
 
         private static void TestProfileValues(IIptcProfile profile) => TestProfileValues(profile, 18);

--- a/tests/Magick.NET.Tests/Shared/Profiles/Iptc/IptcProfileTests.cs
+++ b/tests/Magick.NET.Tests/Shared/Profiles/Iptc/IptcProfileTests.cs
@@ -263,7 +263,7 @@ namespace Magick.NET.Tests
             profile.SetValue(IptcTag.Caption, "test");
 
             // act
-            List<IptcValue> result = profile.GetValues(IptcTag.Byline);
+            List<IIptcValue> result = profile.GetAllValues(IptcTag.Byline);
 
             // assert
             Assert.IsNotNull(result);
@@ -286,7 +286,7 @@ namespace Magick.NET.Tests
             profile.SetDateTimeValue(tag, datetime);
 
             // assert
-            IptcValue actual = profile.GetValues(tag).First();
+            IIptcValue actual = profile.GetValue(tag);
             Assert.AreEqual("19940317", actual.Value);
         }
 
@@ -306,7 +306,7 @@ namespace Magick.NET.Tests
             profile.SetDateTimeValue(tag, dateTimeOffset);
 
             // assert
-            IptcValue actual = profile.GetValues(tag).First();
+            IIptcValue actual = profile.GetAllValues(tag).First();
             Assert.AreEqual("161516+0200", actual.Value);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description

The IPTC specification allows some values to be present more than once. This PR adds the possibility to add those values multiple times. This solves #262.