### PR TITLE
_RootDirectory path is not correctly set in Files.cs

### DIFF
--- a/samples/Magick.NET.Samples/Files/Files.cs
+++ b/samples/Magick.NET.Samples/Files/Files.cs
@@ -14,8 +14,24 @@ namespace Magick.NET.Samples
 {
   public static class SampleFiles
   {
-    private const string _RootDirectory = @"..\..\Samples\Magick.NET\";
-    private const string _FilesDirectory = _RootDirectory + @"Files\";
+    //private const string _RootDirectory = @"..\..\Samples\Magick.NET.Samples\";
+    //private static string _FilesDirectory = _RootDirectory + @"Files\";
+
+    private static string _RootDirectory
+    {
+        get
+        {
+            string curDir = Directory.GetCurrentDirectory();
+            return curDir + @"\..\..\..\..\";
+        }
+    }
+    private static string _FilesDirectory
+    {
+        get
+        {
+            return _RootDirectory + @"Files\";
+        }
+    }
 
     public static string CorruptImageJpg
     {


### PR DESCRIPTION
In my case of .net 40 and x64, the files folder will be C:\Projects\Magick.NET\samples\Magick.NET.Samples\bin\DebugQ16-HDRI\x64\net40\..\..\..\..\files\.

Hopefully this fix can save other dev's time.

Originally it throws error as below.

ImageMagick.MagickBlobErrorException
  HResult=0x80131500
  Message=unable to open image '..\..\Samples\Magick.NET\Files\Snakeware.pdf': No such file or directory @ error/blob.c/OpenBlob/3537
  Source=Magick.NET-Q16-HDRI-x64
  StackTrace:
   at ImageMagick.MagickImageCollection.NativeMagickImageCollection.ReadFile(IMagickSettings`1 settings) in C:\Projects\Magick.NET\src\Magick.NET\Native\MagickImageCollection.cs:line 620
   at ImageMagick.MagickImageCollection.AddImages(String fileName, IMagickReadSettings`1 readSettings, Boolean ping) in C:\Projects\Magick.NET\src\Magick.NET\MagickImageCollection.cs:line 1648
   at ImageMagick.MagickImageCollection.Read(String fileName, IMagickReadSettings`1 readSettings) in C:\Projects\Magick.NET\src\Magick.NET\MagickImageCollection.cs:line 1187
   at Magick.NET.Samples.ConvertPDFSamples.ConvertPDFToMultipleImages() in C:\Projects\Magick.NET\samples\Magick.NET.Samples\ConvertPDF.cs:line 35
   at Magick.NET.Samples.Program.Main(String[] args) in C:\Projects\Magick.NET\samples\Magick.NET.Samples\Program.cs:line 23

### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/dlemstra/Magick.NET/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to Magick.NET! -->