### PR TITLE
Optimize memory usage by leveraging CommunityToolkit.HighPerformance for buffer pooling

### DIFF
--- a/src/Magick.NET.Core/Magick.NET.Core.csproj
+++ b/src/Magick.NET.Core/Magick.NET.Core.csproj
@@ -9,9 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Magick.NET/Extensions/GravityExtensions.cs
+++ b/src/Magick.NET/Extensions/GravityExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace ImageMagick.Extensions
+{
+    internal static class GravityExtensions
+    {
+        private static IImmutableDictionary<Gravity, ReadOnlyMemory<string>> GravityToEdge { get; } =
+            new Dictionary<Gravity, ReadOnlyMemory<string>>
+            {
+                [Gravity.North] = new[] { "north" },
+                [Gravity.Northeast] = new[] { "north", "east" },
+                [Gravity.East] = new[] { "east" },
+                [Gravity.Southeast] = new[] { "south", "east" },
+                [Gravity.South] = new[] { "south" },
+                [Gravity.Southwest] = new[] { "south", "west" },
+                [Gravity.West] = new[] { "west" },
+                [Gravity.Northwest] = new[] { "north", "west" },
+            }.ToImmutableDictionary();
+
+        /// <summary>
+        /// Converts the provided value into edge strings.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>The edge strings composing the given value.</returns>
+        public static ReadOnlyMemory<string> ToEdge(this Gravity value)
+            => GravityToEdge.TryGetValue(value, out var edge) ?
+            edge :
+            ReadOnlyMemory<string>.Empty;
+    }
+}

--- a/src/Magick.NET/Magick.NET.csproj
+++ b/src/Magick.NET/Magick.NET.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
@@ -56,7 +57,7 @@
 
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup> 
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)' == 'arm64'">
     <PlatformTarget>ARM64</PlatformTarget>

--- a/src/Shared/FileHelper.cs
+++ b/src/Shared/FileHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using CommunityToolkit.HighPerformance;
 using System;
 using System.IO;
 using System.Threading;
@@ -43,14 +44,12 @@ namespace ImageMagick
 #endif
         }
 
-        internal static async Task WriteAllBytesAsync(string fileName, byte[] bytes, CancellationToken cancellationToken)
+        internal static Task WriteAllBytesAsync(string fileName, byte[] bytes, CancellationToken cancellationToken) => WriteAllBytesAsync(fileName, bytes.AsMemory(), cancellationToken);
+
+        internal static async Task WriteAllBytesAsync(string fileName, ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken)
         {
-#if NETSTANDARD2_1
-            await File.WriteAllBytesAsync(fileName, bytes, cancellationToken).ConfigureAwait(false);
-#else
             using var fileStream = File.Open(fileName, FileMode.Create, FileAccess.Write);
-            await fileStream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
-#endif
+            await fileStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
This PR proposes leveraging the [Microsoft official package `CommunityToolkit.HighPerformance`](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/high-performance/introduction) (alongside `System.Memory` and `System.Collections.Immutable`) to optimize memory usage by removing intermediate allocations where possible. This is only a small change to the project, but such is the nature of optimization: we can work with incremental steps.

### Description
<!-- A description of the changes proposed in the pull-request -->
This PR aims to optimize memory usage for a few methods of the `ImageMagick.MagickImage` class, namely:
- `void Trim(Gravity[] edges)` now rents a buffer from the shared memory pool when converting edges to their string representations, which means we potentially get rid of intermediate allocations. (Also added a `ReadOnlySpan<Gravity>` overload for users that want to do their own pooling or stack allocate the parameters.)
- Methods writing to a stream or a file now potentially get rid of intermediate allocations caused by `ToByteArray()` by renting a buffer from the shared pool.
- `ToByteArray()` now potentially avoids intermediate allocations by writing the data into `ArrayPoolBufferWriter<byte>` instead of `MemoryStream`, which leverages the array pool to avoid unnecessary allocations, especially when dynamic resizes are needed.

<!-- Thanks for contributing to Magick.NET! -->