### PR TITLE
Updated some documentation.

### DIFF
--- a/docs/CombiningImages.md
+++ b/docs/CombiningImages.md
@@ -33,7 +33,7 @@ images[0].GifDisposeMethod = GifDisposeMethod.Previous; // Prevents frames with 
 // Add the second image, set the animation delay to 100ms, set the disposal method, and flip the image
 images.Add(SampleFiles.SnakewarePng);
 images[1].AnimationDelay = 100;
-images[0].GifDisposeMethod = GifDisposeMethod.Previous;
+images[1].GifDisposeMethod = GifDisposeMethod.Previous;
 images[1].Flip();
 
 // Optionally reduce colors

--- a/docs/CombiningImages.md
+++ b/docs/CombiningImages.md
@@ -25,13 +25,15 @@ result.Write("Mosaic.png");
 ```C#
 using var images = new MagickImageCollection();
 
-// Add first image and set the animation delay to 100ms
+// Add the first image, set the animation delay to 100ms, and set the disposal method
 images.Add(SampleFiles.SnakewarePng);
 images[0].AnimationDelay = 100;
+images[0].GifDisposeMethod = GifDisposeMethod.Previous; // Prevents frames with transparent backgrounds from overlapping each other
 
-// Add second image, set the animation delay to 100ms and flip the image
+// Add the second image, set the animation delay to 100ms, set the disposal method, and flip the image
 images.Add(SampleFiles.SnakewarePng);
 images[1].AnimationDelay = 100;
+images[0].GifDisposeMethod = GifDisposeMethod.Previous;
 images[1].Flip();
 
 // Optionally reduce colors

--- a/samples/Magick.NET.Samples/CombiningImages.cs
+++ b/samples/Magick.NET.Samples/CombiningImages.cs
@@ -30,13 +30,15 @@ public static class CombiningImagesSamples
     {
         using var images = new MagickImageCollection();
 
-        // Add first image and set the animation delay to 100ms
+        // Add the first image, set the animation delay to 100ms, and set the disposal method
         images.Add(SampleFiles.SnakewarePng);
         images[0].AnimationDelay = 100;
+        images[0].GifDisposeMethod = GifDisposeMethod.Previous; // Prevents frames with transparent backgrounds from overlapping each other
 
-        // Add second image, set the animation delay to 100ms and flip the image
+        // Add the second image, set the animation delay to 100ms, set the disposal method, and flip the image
         images.Add(SampleFiles.SnakewarePng);
         images[1].AnimationDelay = 100;
+        images[1].GifDisposeMethod = GifDisposeMethod.Previous;
         images[1].Flip();
 
         // Optionally reduce colors


### PR DESCRIPTION
### Description
<!-- A description of the changes proposed in the pull-request -->

This pull request adds an example on how to use the GifDisposeMethod in the "Create animated gif" examples section.

The reason for adding this change to the documentation is to help those who are trying to figure out how to remove the overlapping effect being caused by frames stacking on top of each other (due to frames having transparency in this instance).

This change should help those who are trying to find a solution to the frame overlapping issue, but without being sent to ImageMagick documentation instead of Magick.NET documentation.

<!-- Thanks for contributing to Magick.NET! -->