### PR TITLE
Add BGRA to PixelMapping.cs

### DIFF
--- a/src/Magick.NET.Core/Enums/PixelMapping.cs
+++ b/src/Magick.NET.Core/Enums/PixelMapping.cs
@@ -32,4 +32,9 @@ public enum PixelMapping
     /// CMYK.
     /// </summary>
     CMYK,
+
+    /// <summary>
+    /// BGRA.
+    /// </summary>
+    BGRA,
 }


### PR DESCRIPTION
This adds BGRA to the PixelMapping enum for convenience

### Description

The specific use case is with `Microsoft.UI.Xaml.Media.Imaging.WriteableBitmap.PixelBuffer` which takes BGRA format.

Placed at the end of the enum to preserve existing values.