### PR TITLE
Update AlphaOption.cs xml docs

### DIFF
--- a/src/Magick.NET.Core/Enums/AlphaOption.cs
+++ b/src/Magick.NET.Core/Enums/AlphaOption.cs
@@ -14,27 +14,34 @@ public enum AlphaOption
     Undefined,
 
     /// <summary>
-    /// Activate.
+    /// Enable the image's transparency channel. Note that normally Set should be used instead of 
+    /// this, unless you specifically need to preserve the existing (but specifically turned Off) 
+    /// transparency channel.
     /// </summary>
     Activate,
 
     /// <summary>
-    /// Associate.
+    /// Associate the alpha channel with the image.
     /// </summary>
     Associate,
 
     /// <summary>
-    /// Background.
+    /// Set any fully-transparent pixel to the background color, while leaving it fully-transparent. 
+    /// This can make some image file formats, such as PNG, smaller as the RGB values of transparent 
+    /// pixels are more uniform, and thus can compress better.
     /// </summary>
     Background,
 
     /// <summary>
-    /// Copy.
+    /// Turns 'On' the alpha/matte channel, then copies the grayscale intensity of the image, into 
+    /// the alpha channel, converting a grayscale mask into a transparent shaped mask ready to be 
+    /// colored appropriately. The color channels are not modified.
     /// </summary>
     Copy,
 
     /// <summary>
-    /// Deactivate.
+    /// Disables the image's transparency channel. This does not delete or change the existing data, 
+    /// it just turns off the use of that data.
     /// </summary>
     Deactivate,
 
@@ -44,12 +51,14 @@ public enum AlphaOption
     Discrete,
 
     /// <summary>
-    /// Disassociate.
+    /// Disassociate the alpha channel from the image.
     /// </summary>
     Disassociate,
 
     /// <summary>
-    /// Extract.
+    /// Copies the alpha channel values into all the color channels and turns 'Off' the image's 
+    /// transparency, so as to generate a grayscale mask of the image's shape. The alpha channel 
+    /// data is left intact just deactivated. This is the inverse of 'Copy'.
     /// </summary>
     Extract,
 
@@ -64,27 +73,32 @@ public enum AlphaOption
     On,
 
     /// <summary>
-    /// Opaque.
+    /// Enables the alpha/matte channel and forces it to be fully opaque.
     /// </summary>
     Opaque,
 
     /// <summary>
-    /// Remove.
+    /// Composite the image over the background color.
     /// </summary>
     Remove,
 
     /// <summary>
-    /// Set.
+    /// Activates the alpha/matte channel. If it was previously turned off then it also 
+    /// resets the channel to opaque. If the image already had the alpha channel turned on, 
+    /// it will have no effect.
     /// </summary>
     Set,
 
     /// <summary>
-    /// Shape.
+    /// As per 'Copy' but also colors the resulting shape mask with the current background color. 
+    /// That is the RGB color channels is replaced, with appropriate alpha shape.
     /// </summary>
     Shape,
 
     /// <summary>
-    /// Transparent.
+    /// Activates the alpha/matte channel and forces it to be fully transparent. This effectively 
+    /// creates a fully transparent image the same size as the original and with all its original 
+    /// RGB data still intact, but fully transparent.
     /// </summary>
     Transparent,
 }

--- a/src/Magick.NET.Core/Enums/AlphaOption.cs
+++ b/src/Magick.NET.Core/Enums/AlphaOption.cs
@@ -14,8 +14,8 @@ public enum AlphaOption
     Undefined,
 
     /// <summary>
-    /// Enable the image's transparency channel. Note that normally Set should be used instead of 
-    /// this, unless you specifically need to preserve the existing (but specifically turned Off) 
+    /// Enable the image's transparency channel. Note that normally Set should be used instead of
+    /// this, unless you specifically need to preserve the existing (but specifically turned Off)
     /// transparency channel.
     /// </summary>
     Activate,
@@ -26,21 +26,21 @@ public enum AlphaOption
     Associate,
 
     /// <summary>
-    /// Set any fully-transparent pixel to the background color, while leaving it fully-transparent. 
-    /// This can make some image file formats, such as PNG, smaller as the RGB values of transparent 
+    /// Set any fully-transparent pixel to the background color, while leaving it fully-transparent.
+    /// This can make some image file formats, such as PNG, smaller as the RGB values of transparent
     /// pixels are more uniform, and thus can compress better.
     /// </summary>
     Background,
 
     /// <summary>
-    /// Turns 'On' the alpha/matte channel, then copies the grayscale intensity of the image, into 
-    /// the alpha channel, converting a grayscale mask into a transparent shaped mask ready to be 
+    /// Turns 'On' the alpha/matte channel, then copies the grayscale intensity of the image, into
+    /// the alpha channel, converting a grayscale mask into a transparent shaped mask ready to be
     /// colored appropriately. The color channels are not modified.
     /// </summary>
     Copy,
 
     /// <summary>
-    /// Disables the image's transparency channel. This does not delete or change the existing data, 
+    /// Disables the image's transparency channel. This does not delete or change the existing data,
     /// it just turns off the use of that data.
     /// </summary>
     Deactivate,
@@ -56,8 +56,8 @@ public enum AlphaOption
     Disassociate,
 
     /// <summary>
-    /// Copies the alpha channel values into all the color channels and turns 'Off' the image's 
-    /// transparency, so as to generate a grayscale mask of the image's shape. The alpha channel 
+    /// Copies the alpha channel values into all the color channels and turns 'Off' the image's
+    /// transparency, so as to generate a grayscale mask of the image's shape. The alpha channel
     /// data is left intact just deactivated. This is the inverse of 'Copy'.
     /// </summary>
     Extract,
@@ -83,21 +83,21 @@ public enum AlphaOption
     Remove,
 
     /// <summary>
-    /// Activates the alpha/matte channel. If it was previously turned off then it also 
-    /// resets the channel to opaque. If the image already had the alpha channel turned on, 
+    /// Activates the alpha/matte channel. If it was previously turned off then it also
+    /// resets the channel to opaque. If the image already had the alpha channel turned on,
     /// it will have no effect.
     /// </summary>
     Set,
 
     /// <summary>
-    /// As per 'Copy' but also colors the resulting shape mask with the current background color. 
+    /// As per 'Copy' but also colors the resulting shape mask with the current background color.
     /// That is the RGB color channels is replaced, with appropriate alpha shape.
     /// </summary>
     Shape,
 
     /// <summary>
-    /// Activates the alpha/matte channel and forces it to be fully transparent. This effectively 
-    /// creates a fully transparent image the same size as the original and with all its original 
+    /// Activates the alpha/matte channel and forces it to be fully transparent. This effectively
+    /// creates a fully transparent image the same size as the original and with all its original
     /// RGB data still intact, but fully transparent.
     /// </summary>
     Transparent,


### PR DESCRIPTION
This copies over the descriptions from the official docs.

### Description

I think adding the full descriptions here would be useful. Although it does present a potential source of maintenance if things change. 

Good or bad to update the xml comments like this in some places?

* Discrete has no documentation
* On/Off don't either, although they are somewhat self-explanatory
* Undefined has... undefined behavior
* Associate/Disassociate docs are somewhat ambiguous compared to the others