### PR TITLE
Update Channels XML comment

### DIFF
--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -427,7 +427,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
         => _nativeInstance.ChannelCount;
 
     /// <summary>
-    /// Gets the channels of the image.
+    /// Gets the color channels of the image.
     /// </summary>
     public IEnumerable<PixelChannel> Channels
     {


### PR DESCRIPTION
Indicate that only color channels are returned.

### Description

I was scratching my head as to why `ChannelCount` and `Channels.Count()` weren't matching until I viewed the source.