### PR TITLE
Use Quantum.Convert for K value in MagickColor

### DIFF
--- a/src/Magick.NET/Colors/MagickColor.cs
+++ b/src/Magick.NET/Colors/MagickColor.cs
@@ -257,7 +257,7 @@ public sealed partial class MagickColor : IMagickColor<QuantumType>
         if (!color.IsCmyk)
             return new MagickColor(red, green, blue, color.A);
 
-        var key = (QuantumType)percentage.Multiply((double)color.K);
+        var key = Quantum.Convert(percentage.Multiply((double)color.K));
 
         return new MagickColor(red, green, blue, key, color.A);
     }


### PR DESCRIPTION
Use Quantum.Convert for K value same as red, green, blue.

I don't find a "good reason" that would explain a simple casting without check. But I'm may be wrong;

Regards.