### PR TITLE
fix: add guards for MagickImage.AdaptiveThreshold

### DIFF
--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -1094,7 +1094,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="height">The height of the pixel neighborhood.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void AdaptiveThreshold(int width, int height)
-        => AdaptiveThreshold(width, height, 0, ImageMagick.Channels.Undefined);
+        => AdaptiveThreshold(width, height, 0.0, ImageMagick.Channels.Undefined);
 
     /// <summary>
     /// Local adaptive threshold image.
@@ -1105,7 +1105,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="channels">The channel(s) that should be thresholded.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void AdaptiveThreshold(int width, int height, Channels channels)
-        => AdaptiveThreshold(width, height, 0, channels);
+        => AdaptiveThreshold(width, height, 0.0, channels);
 
     /// <summary>
     /// Local adaptive threshold image.
@@ -1128,7 +1128,11 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="channels">The channel(s) that should be thresholded.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void AdaptiveThreshold(int width, int height, double bias, Channels channels)
-        => _nativeInstance.AdaptiveThreshold(width, height, bias, channels);
+    {
+        Throw.IfNegative(nameof(width), width);
+        Throw.IfNegative(nameof(height), height);
+        _nativeInstance.AdaptiveThreshold(width, height, bias, channels);
+    }
 
     /// <summary>
     /// Local adaptive threshold image.

--- a/tests/Magick.NET.Tests/MagickImageTests/TheAdaptiveThresholdMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheAdaptiveThresholdMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -10,6 +11,20 @@ public partial class MagickImageTests
 {
     public class TheAdaptiveThresholdMethod
     {
+        [Fact]
+        public void ShouldThrowExceptionWhenWidthIsNegative()
+        {
+            using var image = new MagickImage(Files.MagickNETIconPNG);
+            Assert.Throws<ArgumentException>("width", () => image.AdaptiveThreshold(-1, 10, 0.0, Channels.Red));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenHeightIsNegative()
+        {
+            using var image = new MagickImage(Files.MagickNETIconPNG);
+            Assert.Throws<ArgumentException>("height", () => image.AdaptiveThreshold(10, -1, 0.0, Channels.Red));
+        }
+
         [Fact]
         public void ShouldThresholdTheImage()
         {


### PR DESCRIPTION
:wave:

- [ImageMagick](https://github.com/ImageMagick/ImageMagick/blob/12b1e53ffcf6d4fddfb7222b981bb8324c9b9a97/MagickCore/threshold.c#L219) requires `size_t` for `with` & `height`, but allow 0.
- no checks done on https://github.com/dlemstra/Magick.Native/blob/a01f5e641d52b1bbf2bf6f5795aba4b4c054a22d/src/Magick.Native/MagickImage.c#L700-L711
- no checks done on binding, only casting https://github.com/dlemstra/Magick.NET/blob/dd30d8bf913d79e1b3b7e7f1ea113020ff823751/src/Magick.NET/Native/MagickImage.cs#L3933-L3958

Regards.