### PR TITLE
fix: add guards for MagickImage.BilateralBlur

### DIFF
--- a/src/Magick.NET.Core/IMagickImage.cs
+++ b/src/Magick.NET.Core/IMagickImage.cs
@@ -559,7 +559,8 @@ public partial interface IMagickImage : IDisposable
     /// Applies a non-linear, edge-preserving, and noise-reducing smoothing filter.
     /// </summary>
     /// <param name="width">The width of the neighborhood in pixels.</param>
-    /// <param name="height">The height of the neighborhood in pixels.</param>\
+    /// <param name="height">The height of the neighborhood in pixels.</param>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void BilateralBlur(int width, int height);
 
     /// <summary>
@@ -569,6 +570,7 @@ public partial interface IMagickImage : IDisposable
     /// <param name="height">The height of the neighborhood in pixels.</param>
     /// <param name="intensitySigma">The sigma in the intensity space.</param>
     /// <param name="spatialSigma">The sigma in the coordinate space.</param>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void BilateralBlur(int width, int height, double intensitySigma, double spatialSigma);
 
     /// <summary>

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -1312,10 +1312,12 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <summary>
     /// Applies a non-linear, edge-preserving, and noise-reducing smoothing filter.
     /// </summary>
-    /// <param name="width">The width of the neighborhood in pixels.</param>
-    /// <param name="height">The height of the neighborhood in pixels.</param>
+    /// <param name="width">The width of the neighborhood in pixels (> 0).</param>
+    /// <param name="height">The height of the neighborhood in pixels (> 0).</param>
     public void BilateralBlur(int width, int height)
     {
+        Throw.IfFalse(nameof(width), width > 1, "The width must be > 1");
+        Throw.IfFalse(nameof(height), height > 1, "The height must be > 1");
         var intensitySigma = Math.Sqrt((width * width) + (height * height));
         BilateralBlur(width, height, intensitySigma, intensitySigma * 0.25);
     }
@@ -1323,12 +1325,16 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <summary>
     /// Applies a non-linear, edge-preserving, and noise-reducing smoothing filter.
     /// </summary>
-    /// <param name="width">The width of the neighborhood in pixels.</param>
-    /// <param name="height">The height of the neighborhood in pixels.</param>
+    /// <param name="width">The width of the neighborhood in pixels (> 0).</param>
+    /// <param name="height">The height of the neighborhood in pixels (> 0).</param>
     /// <param name="intensitySigma">The sigma in the intensity space.</param>
     /// <param name="spatialSigma">The sigma in the coordinate space.</param>
     public void BilateralBlur(int width, int height, double intensitySigma, double spatialSigma)
-       => _nativeInstance.BilateralBlur(width, height, intensitySigma, spatialSigma);
+    {
+        Throw.IfFalse(nameof(width), width > 1, "The width must be > 1");
+        Throw.IfFalse(nameof(height), height > 1, "The height must be > 1");
+        _nativeInstance.BilateralBlur(width, height, intensitySigma, spatialSigma);
+    }
 
     /// <summary>
     /// Forces all pixels below the threshold into black while leaving all pixels at or above

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -1312,13 +1312,13 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <summary>
     /// Applies a non-linear, edge-preserving, and noise-reducing smoothing filter.
     /// </summary>
-    /// <param name="width">The width of the neighborhood in pixels (> 0).</param>
-    /// <param name="height">The height of the neighborhood in pixels (> 0).</param>
+    /// <param name="width">The width of the neighborhood in pixels.</param>
+    /// <param name="height">The height of the neighborhood in pixels.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void BilateralBlur(int width, int height)
     {
-        Throw.IfFalse(nameof(width), width > 1, "The width must be > 1");
-        Throw.IfFalse(nameof(height), height > 1, "The height must be > 1");
+        Throw.IfNegative(nameof(width), width);
+        Throw.IfNegative(nameof(height), height);
         var intensitySigma = Math.Sqrt((width * width) + (height * height));
         BilateralBlur(width, height, intensitySigma, intensitySigma * 0.25);
     }
@@ -1326,15 +1326,15 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <summary>
     /// Applies a non-linear, edge-preserving, and noise-reducing smoothing filter.
     /// </summary>
-    /// <param name="width">The width of the neighborhood in pixels (> 0).</param>
-    /// <param name="height">The height of the neighborhood in pixels (> 0).</param>
+    /// <param name="width">The width of the neighborhood in pixels.</param>
+    /// <param name="height">The height of the neighborhood in pixels.</param>
     /// <param name="intensitySigma">The sigma in the intensity space.</param>
     /// <param name="spatialSigma">The sigma in the coordinate space.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void BilateralBlur(int width, int height, double intensitySigma, double spatialSigma)
     {
-        Throw.IfFalse(nameof(width), width > 1, "The width must be > 1");
-        Throw.IfFalse(nameof(height), height > 1, "The height must be > 1");
+        Throw.IfNegative(nameof(width), width);
+        Throw.IfNegative(nameof(height), height);
         _nativeInstance.BilateralBlur(width, height, intensitySigma, spatialSigma);
     }
 

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -1314,6 +1314,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// </summary>
     /// <param name="width">The width of the neighborhood in pixels (> 0).</param>
     /// <param name="height">The height of the neighborhood in pixels (> 0).</param>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void BilateralBlur(int width, int height)
     {
         Throw.IfFalse(nameof(width), width > 1, "The width must be > 1");
@@ -1329,6 +1330,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="height">The height of the neighborhood in pixels (> 0).</param>
     /// <param name="intensitySigma">The sigma in the intensity space.</param>
     /// <param name="spatialSigma">The sigma in the coordinate space.</param>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void BilateralBlur(int width, int height, double intensitySigma, double spatialSigma)
     {
         Throw.IfFalse(nameof(width), width > 1, "The width must be > 1");

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -1319,6 +1319,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     {
         Throw.IfNegative(nameof(width), width);
         Throw.IfNegative(nameof(height), height);
+
         var intensitySigma = Math.Sqrt((width * width) + (height * height));
         BilateralBlur(width, height, intensitySigma, intensitySigma * 0.25);
     }
@@ -1335,6 +1336,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     {
         Throw.IfNegative(nameof(width), width);
         Throw.IfNegative(nameof(height), height);
+
         _nativeInstance.BilateralBlur(width, height, intensitySigma, spatialSigma);
     }
 

--- a/tests/Magick.NET.Tests/MagickImageTests/TheBilateralBlurMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheBilateralBlurMethod.cs
@@ -12,31 +12,31 @@ public partial class MagickImageTests
     public class TheBilateralBlurMethod
     {
         [Fact]
-        public void ShouldThrowExceptionWhenWidthIsLessThanOne()
+        public void ShouldThrowExceptionWhenWidthIsNegative()
         {
             using var image = new MagickImage(Files.NoisePNG);
-            Assert.Throws<ArgumentException>("width", () => image.BilateralBlur(1, 2));
+            Assert.Throws<ArgumentException>("width", () => image.BilateralBlur(-1, 2));
         }
 
         [Fact]
-        public void ShouldThrowExceptionWhenWidthIsLessThanOneWithLowAndHigh()
+        public void ShouldThrowExceptionWhenWidthIsNegativeThanOneWithLowAndHigh()
         {
             using var image = new MagickImage(Files.NoisePNG);
-            Assert.Throws<ArgumentException>("width", () => image.BilateralBlur(1, 2, 0.1, 0.1));
+            Assert.Throws<ArgumentException>("width", () => image.BilateralBlur(-1, 2, 0.1, 0.1));
         }
 
         [Fact]
-        public void ShouldThrowExceptionWhenHeightIsLessThanOne()
+        public void ShouldThrowExceptionWhenHeightIsNegative()
         {
             using var image = new MagickImage(Files.NoisePNG);
-            Assert.Throws<ArgumentException>("height", () => image.BilateralBlur(2, 1));
+            Assert.Throws<ArgumentException>("height", () => image.BilateralBlur(2, -1));
         }
 
         [Fact]
-        public void ShouldThrowExceptionWhenHeightIsLessThanOneWithLowAndHigh()
+        public void ShouldThrowExceptionWhenHeightIsNegativeWithLowAndHigh()
         {
             using var image = new MagickImage(Files.NoisePNG);
-            Assert.Throws<ArgumentException>("height", () => image.BilateralBlur(2, 1, 0.1, 0.1));
+            Assert.Throws<ArgumentException>("height", () => image.BilateralBlur(2, -1, 0.1, 0.1));
         }
 
         [Fact]

--- a/tests/Magick.NET.Tests/MagickImageTests/TheBilateralBlurMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheBilateralBlurMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -10,6 +11,34 @@ public partial class MagickImageTests
 {
     public class TheBilateralBlurMethod
     {
+        [Fact]
+        public void ShouldThrowExceptionWhenWidthIsLessThanOne()
+        {
+            using var image = new MagickImage(Files.NoisePNG);
+            Assert.Throws<ArgumentException>("width", () => image.BilateralBlur(1, 2));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenWidthIsLessThanOneWithLowAndHigh()
+        {
+            using var image = new MagickImage(Files.NoisePNG);
+            Assert.Throws<ArgumentException>("width", () => image.BilateralBlur(1, 2, 0.1, 0.1));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenHeightIsLessThanOne()
+        {
+            using var image = new MagickImage(Files.NoisePNG);
+            Assert.Throws<ArgumentException>("height", () => image.BilateralBlur(2, 1));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenHeightIsLessThanOneWithLowAndHigh()
+        {
+            using var image = new MagickImage(Files.NoisePNG);
+            Assert.Throws<ArgumentException>("height", () => image.BilateralBlur(2, 1, 0.1, 0.1));
+        }
+
         [Fact]
         public void ShouldApplyTheFilter()
         {


### PR DESCRIPTION
:wave:

* https://github.com/ImageMagick/ImageMagick/blob/0c0f0a4e832271a1a37b872e8b76c100e81945c2/MagickCore/effect.c#L896-L897 requires `size_t` for `witdh` & `height` ; some lines later, they are bounded to 1 at minimum
* no checks done on https://github.com/dlemstra/Magick.Native/blob/d0a63d7f3852652c7c5c68c1950a00de015878f5/src/Magick.Native/MagickImage.c#L823-L832
* no checks done on binding, except casting to UInt (so >= 0) https://github.com/dlemstra/Magick.NET/blob/6035129aa06e7033fb8f7e65a8f2206486ae27ff/src/Magick.NET/Native/MagickImage.cs#L4157-L4182

Same could be done for `intensitySigma` & `spatialSigma`, but ImageMagick always multiply each param by itself, making them always positive.

On one hand, it's already "safe".
On the other hand, there is nothing (at least comments) telling it must be `> 0`.

Regards.

Edit: added the exception tag that was missing (even without my modifications)