### PR TITLE
fix: add guards for MagickImage.Clahe

### DIFF
--- a/src/Magick.NET.Core/IMagickImage.cs
+++ b/src/Magick.NET.Core/IMagickImage.cs
@@ -738,6 +738,7 @@ public partial interface IMagickImage : IDisposable
     /// <param name="numberBins">The number of bins for histogram ("dynamic range").</param>
     /// <param name="clipLimit">The contrast limit for localised changes in contrast. A limit less than 1
     /// results in standard non-contrast limited AHE.</param>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void Clahe(Percentage xTiles, Percentage yTiles, int numberBins, double clipLimit);
 
     /// <summary>
@@ -749,6 +750,7 @@ public partial interface IMagickImage : IDisposable
     /// <param name="numberBins">The number of bins for histogram ("dynamic range").</param>
     /// <param name="clipLimit">The contrast limit for localised changes in contrast. A limit less than 1
     /// results in standard non-contrast limited AHE.</param>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void Clahe(int xTiles, int yTiles, int numberBins, double clipLimit);
 
     /// <summary>

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -1552,7 +1552,13 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="clipLimit">The contrast limit for localised changes in contrast. A limit less than 1
     /// results in standard non-contrast limited AHE.</param>
     public void Clahe(int xTiles, int yTiles, int numberBins, double clipLimit)
-        => _nativeInstance.Clahe(xTiles, yTiles, numberBins, clipLimit);
+    {
+        Throw.IfNegative(nameof(xTiles), xTiles);
+        Throw.IfNegative(nameof(yTiles), yTiles);
+        Throw.IfNegative(nameof(numberBins), numberBins);
+
+        _nativeInstance.Clahe(xTiles, yTiles, numberBins, clipLimit);
+    }
 
     /// <summary>
     /// Set each pixel whose value is below zero to zero and any the pixel whose value is above

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -1539,6 +1539,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="numberBins">The number of bins for histogram ("dynamic range").</param>
     /// <param name="clipLimit">The contrast limit for localised changes in contrast. A limit less than 1
     /// results in standard non-contrast limited AHE.</param>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Clahe(Percentage xTiles, Percentage yTiles, int numberBins, double clipLimit)
         => Clahe(Width * xTiles, Height * yTiles, numberBins, clipLimit);
 
@@ -1551,6 +1552,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="numberBins">The number of bins for histogram ("dynamic range").</param>
     /// <param name="clipLimit">The contrast limit for localised changes in contrast. A limit less than 1
     /// results in standard non-contrast limited AHE.</param>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Clahe(int xTiles, int yTiles, int numberBins, double clipLimit)
     {
         Throw.IfNegative(nameof(xTiles), xTiles);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheClaheMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheClaheMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -10,6 +11,27 @@ public partial class MagickImageTests
 {
     public class TheClaheMethod
     {
+        [Fact]
+        public void ShouldThrowExceptionWhenXTilesIsNegative()
+        {
+            using var image = new MagickImage(Files.FujiFilmFinePixS1ProPNG);
+            Assert.Throws<ArgumentException>("xTiles", () => image.Clahe(-10, 20, 30, 1.5));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenYTilesIsNegative()
+        {
+            using var image = new MagickImage(Files.FujiFilmFinePixS1ProPNG);
+            Assert.Throws<ArgumentException>("yTiles", () => image.Clahe(10, -20, 30, 1.5));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenNumberBinsIsNegative()
+        {
+            using var image = new MagickImage(Files.FujiFilmFinePixS1ProPNG);
+            Assert.Throws<ArgumentException>("numberBins", () => image.Clahe(10, 20, -30, 1.5));
+        }
+
         [Fact]
         public void ShouldChangeTheImage()
         {


### PR DESCRIPTION
:wave:

* https://github.com/ImageMagick/ImageMagick/blob/0c0f0a4e832271a1a37b872e8b76c100e81945c2/MagickCore/enhance.c#L616-L785 requires `size_t` for `witdh`, `height` & `number_bins`
* no checks done on https://github.com/dlemstra/Magick.Native/blob/cdf9e6080ac714c8497ffd600b4022a0b4464292/src/Magick.Native/MagickImage.c#L925-L930
* no checks done on binding, except casting to UInt (so >= 0) https://github.com/dlemstra/Magick.NET/blob/167add42cd0875318d6bea71a8ebc14d6bbbb305/src/Magick.NET/Native/MagickImage.cs#L4411-L4433

Regards.

- [x] style: line after checks/`Throw`
- [x] exception tag on interface & impl

Edit: can rebase and/or squash if necessary.
Edit2: rebased because of lasts commit fixing MacOS pipeline