### PR TITLE
typo: fix a lot of typos

### DIFF
--- a/src/Magick.NET.Core/Profiles/Exif/ExifReader.cs
+++ b/src/Magick.NET.Core/Profiles/Exif/ExifReader.cs
@@ -142,7 +142,7 @@ internal sealed class ExifReader
         }
 
         if (value is null)
-            _data.InvalidTags.Add(new UnkownExifTag(tag));
+            _data.InvalidTags.Add(new UnknownExifTag(tag));
 
         _reader.Seek(oldIndex + 4);
 

--- a/src/Magick.NET.Core/Profiles/Exif/Tags/UnknownExifTag.cs
+++ b/src/Magick.NET.Core/Profiles/Exif/Tags/UnknownExifTag.cs
@@ -3,9 +3,9 @@
 
 namespace ImageMagick;
 
-internal sealed class UnkownExifTag : ExifTag
+internal sealed class UnknownExifTag : ExifTag
 {
-    internal UnkownExifTag(ExifTagValue value)
+    internal UnknownExifTag(ExifTagValue value)
         : base((ushort)value)
     {
     }

--- a/src/Magick.NET.Core/Profiles/Exif/Values/ExifValue.cs
+++ b/src/Magick.NET.Core/Profiles/Exif/Values/ExifValue.cs
@@ -11,7 +11,7 @@ internal abstract class ExifValue : IExifValue, IEquatable<ExifTag?>
         => Tag = tag;
 
     public ExifValue(ExifTagValue tag)
-        => Tag = new UnkownExifTag(tag);
+        => Tag = new UnknownExifTag(tag);
 
     public abstract ExifDataType DataType { get; }
 

--- a/src/Magick.NET.SourceGenerator/CodeBuilder.cs
+++ b/src/Magick.NET.SourceGenerator/CodeBuilder.cs
@@ -14,13 +14,13 @@ internal sealed class CodeBuilder
 
     public void Append(int value)
     {
-        AppendIdentation();
+        AppendIndentation();
         _builder.Append(value);
     }
 
     public void Append(params string?[] values)
     {
-        AppendIdentation();
+        AppendIndentation();
 
         foreach (var value in values)
             _builder.Append(value);
@@ -57,7 +57,7 @@ internal sealed class CodeBuilder
     public void AppendLine(params string?[] values)
     {
         if (values.Length > 0)
-            AppendIdentation();
+            AppendIndentation();
 
         foreach (var value in values)
             _builder.Append(value);
@@ -82,7 +82,7 @@ internal sealed class CodeBuilder
     public override string ToString()
         => _builder.ToString();
 
-    private void AppendIdentation()
+    private void AppendIndentation()
     {
         if (_indentationWritten)
             return;

--- a/src/Magick.NET/Types/PointInfoCollection.cs
+++ b/src/Magick.NET/Types/PointInfoCollection.cs
@@ -42,8 +42,8 @@ internal sealed partial class PointInfoCollection : INativeInstance
             return;
         }
 
-        var nativeIstance = new NativePointInfoCollection(instance);
-        nativeIstance.Dispose();
+        var nativeInstance = new NativePointInfoCollection(instance);
+        nativeInstance.Dispose();
     }
 
     public void Dispose()

--- a/tests/Magick.NET.Core.Tests/Profiles/EndianReaderTests/TheSeekMethod.cs
+++ b/tests/Magick.NET.Core.Tests/Profiles/EndianReaderTests/TheSeekMethod.cs
@@ -8,7 +8,7 @@ namespace Magick.NET.Core.Tests;
 
 public partial class EndianReaderTests
 {
-    public class TheSeekMetod
+    public class TheSeekMethod
     {
         [Fact]
         public void ShouldReturnFalseWhenIndexIsTooHigh()

--- a/tests/Magick.NET.Core.Tests/Profiles/Exif/ExifProfileTests/TheToByteArrayMethod.cs
+++ b/tests/Magick.NET.Core.Tests/Profiles/Exif/ExifProfileTests/TheToByteArrayMethod.cs
@@ -26,8 +26,8 @@ public partial class ExifProfileTests
 
             var profile = new ExifProfile(bytes);
 
-            var unkownTag = new ExifTag<uint>((ExifTagValue)298);
-            var value = profile.GetValue<uint>(unkownTag);
+            var unknownTag = new ExifTag<uint>((ExifTagValue)298);
+            var value = profile.GetValue<uint>(unknownTag);
             Assert.Equal(42U, value.GetValue());
             Assert.Equal("42", value.ToString());
 

--- a/tests/Magick.NET.Core.Tests/Profiles/ImageProfileTests/TheGetDataMethod.cs
+++ b/tests/Magick.NET.Core.Tests/Profiles/ImageProfileTests/TheGetDataMethod.cs
@@ -11,7 +11,7 @@ public partial class ImageProfileTests
     public class TheGetDataMethod
     {
         [Fact]
-        public void ShouldReturNullWhenDataIsNull()
+        public void ShouldReturnNullWhenDataIsNull()
         {
             var profile = new TestProfile();
             var bytes = profile.GetData();

--- a/tests/Magick.NET.Core.Tests/Profiles/Iptc/IptcProfileTests/TheSetValueMethod.cs
+++ b/tests/Magick.NET.Core.Tests/Profiles/Iptc/IptcProfileTests/TheSetValueMethod.cs
@@ -28,7 +28,7 @@ public partial class IptcProfileTests
         [InlineData(IptcTag.Contact)]
         [InlineData(IptcTag.LocalCaption)]
         [InlineData(IptcTag.CaptionWriter)]
-        public void ShouldAllowDuplicateValuesForValuesThatCanBeRepated(IptcTag tag)
+        public void ShouldAllowDuplicateValuesForValuesThatCanBeRepeated(IptcTag tag)
         {
             var profile = new IptcProfile();
             var expectedValue1 = "test";
@@ -77,7 +77,7 @@ public partial class IptcProfileTests
         [InlineData(IptcTag.Caption)]
         [InlineData(IptcTag.ImageType)]
         [InlineData(IptcTag.ImageOrientation)]
-        public void ShoulNotdAllowDuplicateValuesForValuesThatCannotBeRepated(IptcTag tag)
+        public void ShouldNotAllowDuplicateValuesForValuesThatCannotBeRepeated(IptcTag tag)
         {
             var profile = new IptcProfile();
             var expectedValue = "another one";

--- a/tests/Magick.NET.Core.Tests/Types/ThresholdTests/TheToStringMethod.cs
+++ b/tests/Magick.NET.Core.Tests/Types/ThresholdTests/TheToStringMethod.cs
@@ -11,7 +11,7 @@ public partial class ThresholdTests
     public class TheToStringMethod
     {
         [Fact]
-        public void ShouldReturnSingleValueWhenOnlyMimimumIsSet()
+        public void ShouldReturnSingleValueWhenOnlyMinimumIsSet()
         {
             var point = new Threshold(1.2);
             Assert.Equal("1.2", point.ToString());

--- a/tests/Magick.NET.Tests/Colors/MagickColorTests/TheOperators.cs
+++ b/tests/Magick.NET.Tests/Colors/MagickColorTests/TheOperators.cs
@@ -89,7 +89,7 @@ public partial class MagickColorTests
             }
 
             [Fact]
-            public void ShouldMultplyAllNonAlphaChannelsForRgbColor()
+            public void ShouldMultiplyAllNonAlphaChannelsForRgbColor()
             {
                 var color = MagickColors.White;
                 var percentage = new Percentage(50);
@@ -104,7 +104,7 @@ public partial class MagickColorTests
             }
 
             [Fact]
-            public void ShouldMultplyAllNonAlphaChannelsForCmykColor()
+            public void ShouldMultiplyAllNonAlphaChannelsForCmykColor()
             {
                 var color = new MagickColor("cmyka(100%,100%,100%,100%)");
                 var percentage = new Percentage(50);

--- a/tests/Magick.NET.Tests/Factories/MagickFactoryTests/TheConfigurationfilesProperty.cs
+++ b/tests/Magick.NET.Tests/Factories/MagickFactoryTests/TheConfigurationfilesProperty.cs
@@ -9,7 +9,7 @@ namespace Magick.NET.Tests;
 
 public partial class MagickFactoryTests
 {
-    public class TheConfigurationfilesProperty
+    public class TheConfigurationFilesProperty
     {
         [Fact]
         public void ShouldReturnInstance()

--- a/tests/Magick.NET.Tests/Factories/MagickFactoryTests/TheQuantumProperty.cs
+++ b/tests/Magick.NET.Tests/Factories/MagickFactoryTests/TheQuantumProperty.cs
@@ -11,7 +11,7 @@ public partial class MagickFactoryTests
     public class TheQuantumInfoProperty
     {
         [Fact]
-        public void ShouldHaveTheCorrectDephValue()
+        public void ShouldHaveTheCorrectDepthValue()
         {
             var factory = new MagickFactory();
 #if Q8

--- a/tests/Magick.NET.Tests/Factories/MagickImageFactoryTests/TheCreateAsyncMethod.cs
+++ b/tests/Magick.NET.Tests/Factories/MagickImageFactoryTests/TheCreateAsyncMethod.cs
@@ -211,8 +211,8 @@ public partial class MagickImageFactoryTests
 
                 var settings = new PixelReadSettings(2, 1, StorageType.Double, PixelMapping.RGBA);
 
-                using var temporaryFile = new TemporaryFile(data);
-                using var image = await factory.CreateAsync(temporaryFile.File.FullName, settings);
+                using var tempFile = new TemporaryFile(data);
+                using var image = await factory.CreateAsync(tempFile.File.FullName, settings);
 
                 Assert.IsType<MagickImage>(image);
                 Assert.Equal(2, image.Width);

--- a/tests/Magick.NET.Tests/Formats/Jpeg/JpegWriteDefinesTests/TheArithmeticCodingProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Jpeg/JpegWriteDefinesTests/TheArithmeticCodingProperty.cs
@@ -27,7 +27,7 @@ public partial class JpegWriteDefinesTests
         }
 
         [Fact]
-        public void ShouldEncodeTheImagArarithmetic()
+        public void ShouldEncodeTheImageArithmetic()
         {
             var defines = new JpegWriteDefines
             {

--- a/tests/Magick.NET.Tests/Formats/Tiff/TiffReadDefinesTests/TheIgnoreExifPopertiesProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Tiff/TiffReadDefinesTests/TheIgnoreExifPopertiesProperty.cs
@@ -9,7 +9,7 @@ namespace Magick.NET.Tests;
 
 public partial class TiffReadDefinesTests
 {
-    public class TheIgnoreExifPopertiesProperty
+    public class TheIgnoreExifPropertiesProperty
     {
         [Fact]
         public void ShouldSetTheDefine()

--- a/tests/Magick.NET.Tests/Helpers/TemporaryDefinesTests/TheSetArtifactMethod.cs
+++ b/tests/Magick.NET.Tests/Helpers/TemporaryDefinesTests/TheSetArtifactMethod.cs
@@ -11,7 +11,7 @@ public partial class TemporaryDefinesTests
     public class TheSetArtifactMethod
     {
         [Fact]
-        public void ShouldSetArtificatWhenValueIsNotNull()
+        public void ShouldSetArtifactWhenValueIsNotNull()
         {
             using var image = new MagickImage();
             using var temporaryDefines = new TemporaryDefines(image);
@@ -21,7 +21,7 @@ public partial class TemporaryDefinesTests
         }
 
         [Fact]
-        public void ShouldNotSetArtificatWhenValueIsNull()
+        public void ShouldNotSetArtifactWhenValueIsNull()
         {
             using var image = new MagickImage();
             using var temporaryDefines = new TemporaryDefines(image);
@@ -31,7 +31,7 @@ public partial class TemporaryDefinesTests
         }
 
         [Fact]
-        public void ShouldNotSetArtificatWhenValueIsEmpty()
+        public void ShouldNotSetArtifactWhenValueIsEmpty()
         {
             using var image = new MagickImage();
             using var temporaryDefines = new TemporaryDefines(image);

--- a/tests/Magick.NET.Tests/MagickImageCollectionTests/TheWriteAsyncMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageCollectionTests/TheWriteAsyncMethod.cs
@@ -56,10 +56,10 @@ public partial class MagickImageCollectionTests
             public async Task ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImageCollection(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
-                await input.WriteAsync(tempfile.File, MagickFormat.Tiff);
+                using var tempFile = new TemporaryFile("foobar");
+                await input.WriteAsync(tempFile.File, MagickFormat.Tiff);
 
-                using var output = new MagickImageCollection(tempfile.File);
+                using var output = new MagickImageCollection(tempFile.File);
 
                 Assert.Single(output);
                 Assert.Equal(MagickFormat.Tiff, output[0].Format);
@@ -90,17 +90,17 @@ public partial class MagickImageCollectionTests
             public async Task ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImageCollection(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
+                using var tempFile = new TemporaryFile("foobar");
                 var defines = new TiffWriteDefines()
                 {
                     Endian = Endian.MSB,
                 };
-                await input.WriteAsync(tempfile.File, defines);
+                await input.WriteAsync(tempFile.File, defines);
 
                 Assert.Equal(MagickFormat.Png, input[0].Format);
 
                 using var output = new MagickImageCollection();
-                await output.ReadAsync(tempfile.File);
+                await output.ReadAsync(tempFile.File);
 
                 Assert.Single(output);
                 Assert.Equal(MagickFormat.Tiff, output[0].Format);
@@ -164,11 +164,11 @@ public partial class MagickImageCollectionTests
             public async Task ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImageCollection(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
+                using var tempFile = new TemporaryFile("foobar");
 
-                await input.WriteAsync(tempfile.File.FullName, MagickFormat.Tiff);
+                await input.WriteAsync(tempFile.File.FullName, MagickFormat.Tiff);
 
-                using var output = new MagickImageCollection(tempfile.File.FullName);
+                using var output = new MagickImageCollection(tempFile.File.FullName);
 
                 Assert.Single(output);
                 Assert.Equal(MagickFormat.Tiff, output[0].Format);
@@ -198,17 +198,17 @@ public partial class MagickImageCollectionTests
             public async Task ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImageCollection(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
+                using var tempFile = new TemporaryFile("foobar");
                 var defines = new TiffWriteDefines()
                 {
                     Endian = Endian.MSB,
                 };
-                await input.WriteAsync(tempfile.File.FullName, defines);
+                await input.WriteAsync(tempFile.File.FullName, defines);
 
                 Assert.Equal(MagickFormat.Png, input[0].Format);
 
                 using var output = new MagickImageCollection();
-                await output.ReadAsync(tempfile.File.FullName);
+                await output.ReadAsync(tempFile.File.FullName);
 
                 Assert.Single(output);
                 Assert.Equal(MagickFormat.Tiff, output[0].Format);

--- a/tests/Magick.NET.Tests/MagickImageCollectionTests/TheWriteMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageCollectionTests/TheWriteMethod.cs
@@ -94,13 +94,13 @@ public partial class MagickImageCollectionTests
                     Endian = Endian.MSB,
                 };
                 using var input = new MagickImageCollection(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
-                input.Write(tempfile.File, defines);
+                using var tempFile = new TemporaryFile("foobar");
+                input.Write(tempFile.File, defines);
 
                 Assert.Equal(MagickFormat.Png, input[0].Format);
 
                 using var output = new MagickImageCollection();
-                output.Read(tempfile.File);
+                output.Read(tempFile.File);
 
                 Assert.Single(output);
                 Assert.Equal(MagickFormat.Tiff, output[0].Format);
@@ -132,12 +132,12 @@ public partial class MagickImageCollectionTests
             public void ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImageCollection(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
-                input.Write(tempfile.File.FullName, MagickFormat.Tiff);
+                using var tempFile = new TemporaryFile("foobar");
+                input.Write(tempFile.File.FullName, MagickFormat.Tiff);
 
                 Assert.Equal(MagickFormat.Png, input[0].Format);
 
-                using var output = new MagickImageCollection(tempfile.File.FullName);
+                using var output = new MagickImageCollection(tempFile.File.FullName);
 
                 Assert.Single(output);
                 Assert.Equal(MagickFormat.Tiff, output[0].Format);
@@ -167,17 +167,17 @@ public partial class MagickImageCollectionTests
             public void ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImageCollection(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
+                using var tempFile = new TemporaryFile("foobar");
                 var defines = new TiffWriteDefines()
                 {
                     Endian = Endian.MSB,
                 };
-                input.Write(tempfile.File.FullName, defines);
+                input.Write(tempFile.File.FullName, defines);
 
                 Assert.Equal(MagickFormat.Png, input[0].Format);
 
                 using var output = new MagickImageCollection();
-                output.Read(tempfile.File.FullName);
+                output.Read(tempFile.File.FullName);
 
                 Assert.Single(output);
                 Assert.Equal(MagickFormat.Tiff, output[0].Format);

--- a/tests/Magick.NET.Tests/MagickImageInfoTests/TheConstructor.cs
+++ b/tests/Magick.NET.Tests/MagickImageInfoTests/TheConstructor.cs
@@ -99,7 +99,7 @@ public partial class MagickImageInfoTests
         public class WithFileNameAndReadSettings
         {
             [Fact]
-            public void ShouldUseTheReadsettings()
+            public void ShouldUseTheReadSettings()
             {
                 var imageInfo = new MagickImageInfo();
                 var settings = new MagickReadSettings(new BmpReadDefines

--- a/tests/Magick.NET.Tests/MagickImageTests/TheBlueShiftMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheBlueShiftMethod.cs
@@ -11,7 +11,7 @@ public partial class MagickImageTests
     public class TheBlueShiftMethod
     {
         [Fact]
-        public void ShouldSimulateNightimeScene()
+        public void ShouldSimulateNighttimeScene()
         {
             using var image = new MagickImage(Files.Builtin.Logo);
 

--- a/tests/Magick.NET.Tests/MagickImageTests/TheBrightnessContrastMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheBrightnessContrastMethod.cs
@@ -11,7 +11,7 @@ public partial class MagickImageTests
     public class TheBrightnessContrastMethod
     {
         [Fact]
-        public void ShouldChangeBrightnesAndContrastOfTheImage()
+        public void ShouldChangeBrightnessAndContrastOfTheImage()
         {
             using var image = new MagickImage(Files.Builtin.Wizard);
 

--- a/tests/Magick.NET.Tests/MagickImageTests/TheColorMatrixMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheColorMatrixMethod.cs
@@ -20,7 +20,7 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void SouldApplyTheSpecifiedColorMatrix()
+        public void ShouldApplyTheSpecifiedColorMatrix()
         {
             using var image = new MagickImage(Files.Builtin.Rose);
             var matrix = new MagickColorMatrix(3, 0, 0, 1, 0, 1, 0, 1, 0, 0);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheCropToTilesMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheCropToTilesMethod.cs
@@ -55,7 +55,7 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShouldCreateTilesOfTheSpeciedSize()
+        public void ShouldCreateTilesOfTheSpecifiedSize()
         {
             using var image = new MagickImage(Files.Builtin.Logo);
             var tiles = image.CropToTiles(48, 48).ToArray();

--- a/tests/Magick.NET.Tests/MagickImageTests/TheDensityProperty.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheDensityProperty.cs
@@ -60,7 +60,7 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShouldUpdateTheDensitOfTheExifProfileInsideThe8BimProfile()
+        public void ShouldUpdateTheDensityOfTheExifProfileInsideThe8BimProfile()
         {
             using var input = new MagickImage(Files.EightBimJPG);
             input.Density = new Density(96);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheNegateGrayscaleMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheNegateGrayscaleMethod.cs
@@ -26,7 +26,7 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShouldNegateTheSpecifedChannels()
+        public void ShouldNegateTheSpecifiedChannels()
         {
             using var image = new MagickImage("xc:white", 2, 1);
             using var pixels = image.GetPixels();

--- a/tests/Magick.NET.Tests/MagickImageTests/TheNegateMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheNegateMethod.cs
@@ -20,7 +20,7 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShouldNegateTheSpecifedChannels()
+        public void ShouldNegateTheSpecifiedChannels()
         {
             using var image = new MagickImage("xc:white", 1, 1);
             image.Negate(Channels.Red);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheReadPixelsAsyncMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheReadPixelsAsyncMethod.cs
@@ -131,9 +131,9 @@ public partial class MagickImageTests
                 var settings = new PixelReadSettings(1, 1, StorageType.Short, "R");
                 var bytes = BitConverter.GetBytes(ushort.MaxValue);
 
-                using var temporyFile = new TemporaryFile(bytes);
+                using var tempFile = new TemporaryFile(bytes);
                 using var image = new MagickImage();
-                await image.ReadPixelsAsync(temporyFile.File.FullName, settings);
+                await image.ReadPixelsAsync(tempFile.File.FullName, settings);
 
                 Assert.Equal(1, image.Width);
                 Assert.Equal(1, image.Height);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheReadPixelsMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheReadPixelsMethod.cs
@@ -424,9 +424,9 @@ public partial class MagickImageTests
                 var settings = new PixelReadSettings(1, 1, StorageType.Float, "R");
                 var bytes = BitConverter.GetBytes(1.0F);
 
-                using var temporyFile = new TemporaryFile(bytes);
+                using var tempFile = new TemporaryFile(bytes);
                 using var image = new MagickImage();
-                image.ReadPixels(temporyFile.File, settings);
+                image.ReadPixels(tempFile.File, settings);
 
                 Assert.Equal(1, image.Width);
                 Assert.Equal(1, image.Height);
@@ -509,9 +509,9 @@ public partial class MagickImageTests
             {
                 var settings = new PixelReadSettings(1, 1, StorageType.Short, "R");
                 var bytes = BitConverter.GetBytes(ushort.MaxValue);
-                using var temporyFile = new TemporaryFile(bytes);
+                using var tempFile = new TemporaryFile(bytes);
                 using var image = new MagickImage();
-                image.ReadPixels(temporyFile.File.FullName, settings);
+                image.ReadPixels(tempFile.File.FullName, settings);
 
                 Assert.Equal(1, image.Width);
                 Assert.Equal(1, image.Height);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheSetBitDepthMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheSetBitDepthMethod.cs
@@ -11,7 +11,7 @@ public partial class MagickImageTests
     public class TheSetBitDepthMethod
     {
         [Fact]
-        public void ShouldChangeTheBithDepth()
+        public void ShouldChangeTheBitDepth()
         {
             using var image = new MagickImage(Files.RoseSparkleGIF);
             image.SetBitDepth(1);
@@ -20,7 +20,7 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShouldChangeTheBithDepthForTheSpecifiedChannel()
+        public void ShouldChangeTheBitDepthForTheSpecifiedChannel()
         {
             using var image = new MagickImage(Files.RoseSparkleGIF);
             image.SetBitDepth(1, Channels.Red);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheSetClippingPathMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheSetClippingPathMethod.cs
@@ -26,7 +26,7 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShouldSetTheClippingPathWithTheSpecfiedName()
+        public void ShouldSetTheClippingPathWithTheSpecifiedName()
         {
             using var image = new MagickImage(Files.MagickNETIconPNG);
 

--- a/tests/Magick.NET.Tests/MagickImageTests/TheThresholdMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheThresholdMethod.cs
@@ -38,7 +38,7 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShoulThrowExceptionOn32BitPlatformWhenChannelIsTooHigh()
+        public void ShouldThrowExceptionOn32BitPlatformWhenChannelIsTooHigh()
         {
             if (Runtime.Is64Bit)
                 return;

--- a/tests/Magick.NET.Tests/MagickImageTests/TheWriteAsyncMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheWriteAsyncMethod.cs
@@ -57,12 +57,12 @@ public partial class MagickImageTests
             {
                 using var input = new MagickImage(Files.CirclePNG);
 
-                using var tempfile = new TemporaryFile("foobar");
-                await input.WriteAsync(tempfile.File, MagickFormat.Tiff);
+                using var tempFile = new TemporaryFile("foobar");
+                await input.WriteAsync(tempFile.File, MagickFormat.Tiff);
 
                 Assert.Equal(MagickFormat.Png, input.Format);
 
-                using var output = new MagickImage(tempfile.File);
+                using var output = new MagickImage(tempFile.File);
 
                 Assert.Equal(MagickFormat.Tiff, output.Format);
             }
@@ -97,13 +97,13 @@ public partial class MagickImageTests
                 };
                 using var input = new MagickImage(Files.CirclePNG);
 
-                using var tempfile = new TemporaryFile("foobar");
-                await input.WriteAsync(tempfile.File, defines);
+                using var tempFile = new TemporaryFile("foobar");
+                await input.WriteAsync(tempFile.File, defines);
 
                 Assert.Equal(MagickFormat.Png, input.Format);
 
                 using var output = new MagickImage();
-                await output.ReadAsync(tempfile.File);
+                await output.ReadAsync(tempFile.File);
 
                 Assert.Equal(MagickFormat.Jpeg, output.Format);
             }
@@ -163,12 +163,12 @@ public partial class MagickImageTests
             {
                 using var input = new MagickImage(Files.CirclePNG);
 
-                using var tempfile = new TemporaryFile("foobar");
-                await input.WriteAsync(tempfile.File.FullName, MagickFormat.Tiff);
+                using var tempFile = new TemporaryFile("foobar");
+                await input.WriteAsync(tempFile.File.FullName, MagickFormat.Tiff);
 
                 Assert.Equal(MagickFormat.Png, input.Format);
 
-                using var output = new MagickImage(tempfile.File.FullName);
+                using var output = new MagickImage(tempFile.File.FullName);
 
                 Assert.Equal(MagickFormat.Tiff, output.Format);
             }
@@ -204,13 +204,13 @@ public partial class MagickImageTests
 
                 using var input = new MagickImage(Files.CirclePNG);
 
-                using var tempfile = new TemporaryFile("foobar");
-                await input.WriteAsync(tempfile.File.FullName, defines);
+                using var tempFile = new TemporaryFile("foobar");
+                await input.WriteAsync(tempFile.File.FullName, defines);
 
                 Assert.Equal(MagickFormat.Png, input.Format);
 
                 using var output = new MagickImage();
-                await output.ReadAsync(tempfile.File.FullName);
+                await output.ReadAsync(tempFile.File.FullName);
 
                 Assert.Equal(MagickFormat.Jpeg, output.Format);
             }

--- a/tests/Magick.NET.Tests/MagickImageTests/TheWriteMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheWriteMethod.cs
@@ -55,13 +55,13 @@ public partial class MagickImageTests
             public void ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImage(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar.jpg");
+                using var tempFile = new TemporaryFile("foobar.jpg");
 
-                input.Write(tempfile.File, MagickFormat.Tiff);
+                input.Write(tempFile.File, MagickFormat.Tiff);
 
                 Assert.Equal(MagickFormat.Png, input.Format);
 
-                using var output = new MagickImage(tempfile.File);
+                using var output = new MagickImage(tempFile.File);
 
                 Assert.Equal(MagickFormat.Tiff, output.Format);
             }
@@ -91,17 +91,17 @@ public partial class MagickImageTests
             public void ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImage(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
+                using var tempFile = new TemporaryFile("foobar");
 
                 var defines = new JpegWriteDefines
                 {
                     DctMethod = JpegDctMethod.Fast,
                 };
-                input.Write(tempfile.File, defines);
+                input.Write(tempFile.File, defines);
 
                 Assert.Equal(MagickFormat.Png, input.Format);
 
-                using var output = new MagickImage(tempfile.File);
+                using var output = new MagickImage(tempFile.File);
 
                 Assert.Equal(MagickFormat.Jpeg, output.Format);
             }
@@ -176,12 +176,12 @@ public partial class MagickImageTests
             public void ShouldUseTheSpecifiedFormat()
             {
                 using var input = new MagickImage(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
-                input.Write(tempfile.File.FullName, MagickFormat.Tiff);
+                using var tempFile = new TemporaryFile("foobar");
+                input.Write(tempFile.File.FullName, MagickFormat.Tiff);
 
                 Assert.Equal(MagickFormat.Png, input.Format);
 
-                using var output = new MagickImage(tempfile.File.FullName);
+                using var output = new MagickImage(tempFile.File.FullName);
 
                 Assert.Equal(MagickFormat.Tiff, output.Format);
             }
@@ -223,12 +223,12 @@ public partial class MagickImageTests
                     DctMethod = JpegDctMethod.Fast,
                 };
                 using var input = new MagickImage(Files.CirclePNG);
-                using var tempfile = new TemporaryFile("foobar");
-                input.Write(tempfile.File.FullName, defines);
+                using var tempFile = new TemporaryFile("foobar");
+                input.Write(tempFile.File.FullName, defines);
 
                 Assert.Equal(MagickFormat.Png, input.Format);
 
-                using var output = new MagickImage(tempfile.File.FullName);
+                using var output = new MagickImage(tempFile.File.FullName);
 
                 Assert.Equal(MagickFormat.Jpeg, output.Format);
             }

--- a/tests/Magick.NET.Tests/MagickNETTests/TheLogEvent.cs
+++ b/tests/Magick.NET.Tests/MagickNETTests/TheLogEvent.cs
@@ -14,7 +14,7 @@ public partial class MagickNETTests
         [Fact]
         public void ShouldPassOrderedTests()
         {
-            ShouldNotCallLogDelegeteWhenLogEventsAreNotSet();
+            ShouldNotCallLogDelegateWhenLogEventsAreNotSet();
 
             ShouldCallLogDelegateWhenLogEventsAreSet();
 
@@ -23,7 +23,7 @@ public partial class MagickNETTests
             ShouldStopCallingLogDelegateWhenLogDelegateIsRemoved();
         }
 
-        private void ShouldNotCallLogDelegeteWhenLogEventsAreNotSet()
+        private void ShouldNotCallLogDelegateWhenLogEventsAreNotSet()
         {
             var count = 0;
             void LogDelegate(object sender, LogEventArgs arguments)

--- a/tests/Magick.NET.Tests/Matrices/MagickColorMatrixTests/TheConstructor.cs
+++ b/tests/Magick.NET.Tests/Matrices/MagickColorMatrixTests/TheConstructor.cs
@@ -52,7 +52,7 @@ public partial class MagickColorMatrixTests
         }
 
         [Fact]
-        public void ShouldThroWExceptionWhenOrderIsTooLowAndValuesAreProvided()
+        public void ShouldThrowExceptionWhenOrderIsTooLowAndValuesAreProvided()
         {
             Assert.Throws<ArgumentException>("order", () =>
             {
@@ -61,7 +61,7 @@ public partial class MagickColorMatrixTests
         }
 
         [Fact]
-        public void ShouldThroWExceptionWhenOrderIsTooHighAndValuesAreProvided()
+        public void ShouldThrowExceptionWhenOrderIsTooHighAndValuesAreProvided()
         {
             Assert.Throws<ArgumentException>("order", () =>
             {

--- a/tests/Magick.NET.Tests/Matrices/MagickColorMatrixTests/TheSetColumnMethod.cs
+++ b/tests/Magick.NET.Tests/Matrices/MagickColorMatrixTests/TheSetColumnMethod.cs
@@ -20,7 +20,7 @@ public partial class MagickColorMatrixTests
             => TestThrowsException(2);
 
         [Fact]
-        public void ShoulddThrowExceptionWhenValuesIsNul()
+        public void ShouldThrowExceptionWhenValuesIsNul()
         {
             var matrix = new MagickColorMatrix(2);
 

--- a/tests/Magick.NET.Tests/Matrices/MagickColorMatrixTests/TheSetRowMethod.cs
+++ b/tests/Magick.NET.Tests/Matrices/MagickColorMatrixTests/TheSetRowMethod.cs
@@ -20,7 +20,7 @@ public partial class MagickColorMatrixTests
             => TestThrowsException(2);
 
         [Fact]
-        public void ShoulddThrowExceptionWhenValuesIsNul()
+        public void ShouldThrowExceptionWhenValuesIsNul()
         {
             var matrix = new MagickColorMatrix(2);
 

--- a/tests/Magick.NET.Tests/Netstandard21/MagickImageCollectionTests/ThePingMethod.cs
+++ b/tests/Magick.NET.Tests/Netstandard21/MagickImageCollectionTests/ThePingMethod.cs
@@ -55,7 +55,7 @@ public partial class MagickImageCollectionTests
             }
         }
 
-        public class WithReadOnlySequencenAndMagickReadSettings
+        public class WithReadOnlySequenceAndMagickReadSettings
         {
             [Fact]
             public void ShouldNotThrowExceptionWhenSettingsIsNull()
@@ -112,4 +112,3 @@ public partial class MagickImageCollectionTests
 }
 
 #endif
-

--- a/tests/Magick.NET.Tests/Netstandard21/MagickImageTests/TheConstructor.cs
+++ b/tests/Magick.NET.Tests/Netstandard21/MagickImageTests/TheConstructor.cs
@@ -87,7 +87,7 @@ public partial class MagickImageTests
             }
         }
 
-        public class WithReadOnlySpanyAndPixelReadSettings
+        public class WithReadOnlySpanAndPixelReadSettings
         {
             [Fact]
             public void ShouldThrowExceptionWhenDataIsEmpty()

--- a/tests/Magick.NET.Tests/Optimizers/ImageOptimizerTests/TheLosslessCompressMethod.cs
+++ b/tests/Magick.NET.Tests/Optimizers/ImageOptimizerTests/TheLosslessCompressMethod.cs
@@ -284,7 +284,7 @@ public partial class ImageOptimizerTests
             }
 
             [Fact]
-            public void ShouldMakeFileSmallerWhenStreamIsCompressibleJpgStrea()
+            public void ShouldMakeFileSmallerWhenStreamIsCompressibleJpgStream()
             {
                 var optimizer = new ImageOptimizer();
 

--- a/tests/Magick.NET.Tests/Pixels/UnsafePixelCollectionTests/TheGetAreaMethod.cs
+++ b/tests/Magick.NET.Tests/Pixels/UnsafePixelCollectionTests/TheGetAreaMethod.cs
@@ -12,7 +12,7 @@ public partial class UnsafePixelCollectionTests
     public class TheGetAreaMethod
     {
         [Fact]
-        public void ShouldTNothrowExceptionWhendXTooLow()
+        public void ShouldTNothrowExceptionWhenXTooLow()
             => ThrowsNoException(-1, 0, 1, 1);
 
         [Fact]

--- a/tests/Magick.NET.Tests/Pixels/UnsafePixelCollectionTests/TheGetAreaPointerMethod.cs
+++ b/tests/Magick.NET.Tests/Pixels/UnsafePixelCollectionTests/TheGetAreaPointerMethod.cs
@@ -22,7 +22,7 @@ public partial class UnsafePixelCollectionTests
     public class TheGetAreaPointerMethod
     {
         [Fact]
-        public void ShouldNotThrowExceptionWhendXTooLow()
+        public void ShouldNotThrowExceptionWhenXTooLow()
             => ThrowsNoException(-1, 0, 1, 1);
 
         [Fact]


### PR DESCRIPTION
:wave: 

Run a typo inspection on the whole solution and fix them manually:
- mostly in test methods
- variable name harmonization (`tempfile`, `tempFile`... -> `tempFile` everywhere because it was the most used)
- :warning: Internal class (`UnkownExifTag` -> `UnknownExifTag`) ; since it's an internal, it should not be a problem

Regards

Edit:

Some I can't tell if they are or not:
- `Uncompressible` should not be `Incompressible` ?