### PR TITLE
typo: TiffReadDefines.IgnoreExifPoperties -> IgnoreExifProperties

### DIFF
--- a/src/Magick.NET/Formats/Tiff/TiffReadDefines.cs
+++ b/src/Magick.NET/Formats/Tiff/TiffReadDefines.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 
 namespace ImageMagick.Formats;
@@ -19,7 +20,17 @@ public sealed class TiffReadDefines : IReadDefines
     /// <summary>
     /// Gets or sets a value indicating whether the exif profile should be ignored (tiff:exif-properties).
     /// </summary>
-    public bool? IgnoreExifPoperties { get; set; }
+    [Obsolete($"This property will be removed in the next major release, use {nameof(IgnoreExifProperties)} instead.")]
+    public bool? IgnoreExifPoperties
+    {
+        get => IgnoreExifProperties;
+        set => IgnoreExifProperties = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the exif profile should be ignored (tiff:exif-properties).
+    /// </summary>
+    public bool? IgnoreExifProperties { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the layers should be ignored (tiff:ignore-layers).
@@ -38,7 +49,7 @@ public sealed class TiffReadDefines : IReadDefines
     {
         get
         {
-            if (IgnoreExifPoperties.Equals(true))
+            if (IgnoreExifProperties.Equals(true))
                 yield return new MagickDefine(Format, "exif-properties", false);
 
             if (IgnoreLayers is not null)

--- a/tests/Magick.NET.Tests/Formats/Tiff/TiffReadDefinesTests/TheIgnoreExifPopertiesProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Tiff/TiffReadDefinesTests/TheIgnoreExifPopertiesProperty.cs
@@ -17,7 +17,7 @@ public partial class TiffReadDefinesTests
             using var image = new MagickImage();
             image.Settings.SetDefines(new TiffReadDefines
             {
-                IgnoreExifPoperties = true,
+                IgnoreExifProperties = true,
             });
 
             Assert.Equal("false", image.Settings.GetDefine(MagickFormat.Tiff, "exif-properties"));
@@ -29,7 +29,7 @@ public partial class TiffReadDefinesTests
             using var image = new MagickImage();
             image.Settings.SetDefines(new TiffReadDefines
             {
-                IgnoreExifPoperties = false,
+                IgnoreExifProperties = false,
             });
 
             Assert.Null(image.Settings.GetDefine(MagickFormat.Tiff, "exif-properties"));
@@ -42,7 +42,7 @@ public partial class TiffReadDefinesTests
             {
                 Defines = new TiffReadDefines
                 {
-                    IgnoreExifPoperties = true,
+                    IgnoreExifProperties = true,
                 },
             };
 


### PR DESCRIPTION
:wave: 

Fixed a typo in `TiffReadDefines`: `IgnoreExifPoperties` -> `IgnoreExifProperties` ; since it's part of the public api, I kept the old one and make it Obsolete.

I guess it should go there https://github.com/dlemstra/Magick.NET/issues/1374.

Regards.