### PR TITLE
fix: add guards for MagickImage.HoughLine

### DIFF
--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -3328,7 +3328,13 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="threshold">The line count threshold.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void HoughLine(int width, int height, int threshold)
-        => _nativeInstance.HoughLine(width, height, threshold);
+    {
+        Throw.IfNegative(nameof(width), width);
+        Throw.IfNegative(nameof(height), height);
+        Throw.IfNegative(nameof(threshold), threshold);
+
+        _nativeInstance.HoughLine(width, height, threshold);
+    }
 
     /// <summary>
     /// Implode image (special effect).

--- a/tests/Magick.NET.Tests/MagickImageTests/TheHoughLineMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheHoughLineMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -10,6 +11,27 @@ public partial class MagickImageTests
 {
     public class TheHoughLineMethod
     {
+        [Fact]
+        public void ShouldThrowExceptionWhenWidthIsNegative()
+        {
+            using var image = new MagickImage(Files.ConnectedComponentsPNG);
+            Assert.Throws<ArgumentException>("width", () => image.HoughLine(-1, 0, 0));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenHeightIsNegative()
+        {
+            using var image = new MagickImage(Files.ConnectedComponentsPNG);
+            Assert.Throws<ArgumentException>("height", () => image.HoughLine(0, -1, 0));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenThresholdIsNegative()
+        {
+            using var image = new MagickImage(Files.ConnectedComponentsPNG);
+            Assert.Throws<ArgumentException>("threshold", () => image.HoughLine(0, 0, -1));
+        }
+
         [Fact]
         public void ShouldIdentifyLinesInImage()
         {


### PR DESCRIPTION
:wave:

* https://github.com/ImageMagick/ImageMagick/blob/365d9b6f698234093d7a919f090bd5ce87b2104a/MagickCore/feature.c#L1830-L1832 requires `size_t` for `width`, `height` & `threshold`
* no checks done on https://github.com/dlemstra/Magick.Native/blob/9bf4e0f8df0f7e8a301e494f8049d2d19b2318ff/src/Magick.Native/MagickImage.c#L1585-L1594
* no checks done on binding, except casting to UInt (so >= 0) https://github.com/dlemstra/Magick.NET/blob/9c11be7fdd20c87d0b51718112cbd357e34c96c4/src/Magick.NET/Native/MagickImage.cs#L6003-L6028