### PR TITLE
fix: add guards for MagickImage.Lower

### DIFF
--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -3995,7 +3995,11 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="size">The size of the edges.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Lower(int size)
-        => _nativeInstance.RaiseOrLower(size, false);
+    {
+        Throw.IfNegative(nameof(size), size);
+
+        _nativeInstance.RaiseOrLower(size, false);
+    }
 
     /// <summary>
     /// Magnify image by integral size.

--- a/tests/Magick.NET.Tests/MagickImageTests/TheLowerMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheLowerMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -10,6 +11,13 @@ public partial class MagickImageTests
 {
     public class TheLowerMethod
     {
+        [Fact]
+        public void ShouldThrowExceptionWhenSizeIsNegative()
+        {
+            using var image = new MagickImage(Files.FujiFilmFinePixS1ProJPG);
+            Assert.Throws<ArgumentException>("width", () => image.Lower(-1));
+        }
+
         [Fact]
         public void ShouldDarkenTheEdges()
         {

--- a/tests/Magick.NET.Tests/MagickImageTests/TheLowerMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheLowerMethod.cs
@@ -15,7 +15,7 @@ public partial class MagickImageTests
         public void ShouldThrowExceptionWhenSizeIsNegative()
         {
             using var image = new MagickImage(Files.FujiFilmFinePixS1ProJPG);
-            Assert.Throws<ArgumentException>("width", () => image.Lower(-1));
+            Assert.Throws<ArgumentException>("size", () => image.Lower(-1));
         }
 
         [Fact]


### PR DESCRIPTION
:wave:

* https://github.com/ImageMagick/ImageMagick/blob/0deac72ed480ac2ec8e9d766c15ddb3bca055952/MagickCore/geometry.h#L129-L138 requires `size_t` for `width`, `height` ; struct used in https://github.com/ImageMagick/ImageMagick/blob/0deac72ed480ac2ec8e9d766c15ddb3bca055952/MagickCore/decorate.c#L628-L631
* https://github.com/dlemstra/Magick.Native/blob/4b111a550d57c4e7c95ba9bc486581c07981d9d4/src/Magick.Native/MagickImage.c#L1920-L1930 requires `size_t` for `size`
* no checks done on binding, except casting to UInt (so >= 0) https://github.com/dlemstra/Magick.NET/blob/f66b8aaf27a7e3d3f32fbf4605154f32573b1cd4/src/Magick.NET/Native/MagickImage.cs#L6829-L6851

Regards 🙂