### PR TITLE
feat: make Percentage only positive

### DIFF
--- a/src/Magick.NET.Core/Types/Percentage.cs
+++ b/src/Magick.NET.Core/Types/Percentage.cs
@@ -16,7 +16,7 @@ public readonly struct Percentage : IEquatable<Percentage>, IComparable<Percenta
     /// <summary>
     /// Initializes a new instance of the <see cref="Percentage"/> struct.
     /// </summary>
-    /// <param name="value">The value (0% = 0.0, 100% = 100.0).</param>
+    /// <param name="value">The value (0% = 0.0, 100% = 100.0, 142.42% = 142.42).</param>
     public Percentage(double value)
     {
         Throw.IfNegative(nameof(value), value);
@@ -27,7 +27,7 @@ public readonly struct Percentage : IEquatable<Percentage>, IComparable<Percenta
     /// <summary>
     /// Initializes a new instance of the <see cref="Percentage"/> struct.
     /// </summary>
-    /// <param name="value">The value (0% = 0, 100% = 100).</param>
+    /// <param name="value">The value (0% = 0, 100% = 100, 142% = 142).</param>
     public Percentage(int value)
     {
         Throw.IfNegative(nameof(value), value);
@@ -38,14 +38,14 @@ public readonly struct Percentage : IEquatable<Percentage>, IComparable<Percenta
     /// <summary>
     /// Converts the specified double to an instance of this type.
     /// </summary>
-    /// <param name="value">The value (0% = 0, 100% = 100).</param>
+    /// <param name="value">The value (0% = 0.0, 100% = 100.0, 142.42% = 142.42).</param>
     public static explicit operator Percentage(double value)
         => new Percentage(value);
 
     /// <summary>
     /// Converts the specified int to an instance of this type.
     /// </summary>
-    /// <param name="value">The value (0% = 0, 100% = 100).</param>
+    /// <param name="value">The value (0% = 0, 100% = 100, 142% = 142).</param>
     public static explicit operator Percentage(int value)
         => new Percentage(value);
 

--- a/src/Magick.NET.Core/Types/Percentage.cs
+++ b/src/Magick.NET.Core/Types/Percentage.cs
@@ -18,14 +18,22 @@ public readonly struct Percentage : IEquatable<Percentage>, IComparable<Percenta
     /// </summary>
     /// <param name="value">The value (0% = 0.0, 100% = 100.0).</param>
     public Percentage(double value)
-        => _value = value;
+    {
+        Throw.IfNegative(nameof(value), value);
+
+        _value = value;
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Percentage"/> struct.
     /// </summary>
     /// <param name="value">The value (0% = 0, 100% = 100).</param>
     public Percentage(int value)
-        => _value = value;
+    {
+        Throw.IfNegative(nameof(value), value);
+
+        _value = value;
+    }
 
     /// <summary>
     /// Converts the specified double to an instance of this type.
@@ -170,7 +178,11 @@ public readonly struct Percentage : IEquatable<Percentage>, IComparable<Percenta
     /// <param name="value">The value to use.</param>
     /// <returns>The new value.</returns>
     public double Multiply(double value)
-        => (value * _value) / 100.0;
+    {
+        Throw.IfNegative(nameof(value), value);
+
+        return (value * _value) / 100.0;
+    }
 
     /// <summary>
     /// Multiplies the value by the specified percentage.
@@ -178,7 +190,11 @@ public readonly struct Percentage : IEquatable<Percentage>, IComparable<Percenta
     /// <param name="value">The value to use.</param>
     /// <returns>The new value.</returns>
     public int Multiply(int value)
-        => (int)((value * _value) / 100.0);
+    {
+        Throw.IfNegative(nameof(value), value);
+
+        return (int)((value * _value) / 100.0);
+    }
 
     /// <summary>
     /// Returns a double that represents the current percentage.

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -1358,11 +1358,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="channels">The channel(s) to make black.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void BlackThreshold(Percentage threshold, Channels channels)
-    {
-        Throw.IfNegative(nameof(threshold), threshold);
-
-        _nativeInstance.BlackThreshold(threshold.ToString(), channels);
-    }
+        => _nativeInstance.BlackThreshold(threshold.ToString(), channels);
 
     /// <summary>
     /// Simulate a scene at nighttime in the moonlight.
@@ -1736,11 +1732,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="alpha">The alpha percentage.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Colorize(IMagickColor<QuantumType> color, Percentage alpha)
-    {
-        Throw.IfNegative(nameof(alpha), alpha);
-
-        Colorize(color, alpha, alpha, alpha);
-    }
+        => Colorize(color, alpha, alpha, alpha);
 
     /// <summary>
     /// Colorize image with the specified color, using specified percent alpha for red, green,
@@ -1754,9 +1746,6 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     public void Colorize(IMagickColor<QuantumType> color, Percentage alphaRed, Percentage alphaGreen, Percentage alphaBlue)
     {
         Throw.IfNull(nameof(color), color);
-        Throw.IfNegative(nameof(alphaRed), alphaRed);
-        Throw.IfNegative(nameof(alphaGreen), alphaGreen);
-        Throw.IfNegative(nameof(alphaBlue), alphaBlue);
 
         var blend = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2}", alphaRed.ToInt32(), alphaGreen.ToInt32(), alphaBlue.ToInt32());
 
@@ -2282,9 +2271,6 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void ContrastStretch(Percentage blackPoint, Percentage whitePoint, Channels channels)
     {
-        Throw.IfNegative(nameof(blackPoint), blackPoint);
-        Throw.IfNegative(nameof(whitePoint), whitePoint);
-
         var contrast = CalculateContrastStretch(blackPoint, whitePoint);
         _nativeInstance.ContrastStretch(contrast.X, contrast.Y, channels);
     }
@@ -2500,7 +2486,6 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     public double Deskew(IDeskewSettings settings)
     {
         Throw.IfNull(nameof(settings), settings);
-        Throw.IfNegative(nameof(settings), settings.Threshold);
 
         using var temporaryDefines = new TemporaryDefines(this);
         temporaryDefines.SetArtifact("deskew:auto-crop", settings.AutoCrop);
@@ -3849,12 +3834,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="whitePoint">The white point.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void LinearStretch(Percentage blackPoint, Percentage whitePoint)
-    {
-        Throw.IfNegative(nameof(blackPoint), blackPoint);
-        Throw.IfNegative(nameof(whitePoint), whitePoint);
-
-        _nativeInstance.LinearStretch(PercentageHelper.ToQuantum(blackPoint), PercentageHelper.ToQuantum(whitePoint));
-    }
+        => _nativeInstance.LinearStretch(PercentageHelper.ToQuantum(blackPoint), PercentageHelper.ToQuantum(whitePoint));
 
     /// <summary>
     /// Rescales image with seam carving.
@@ -4125,10 +4105,6 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Modulate(Percentage brightness, Percentage saturation, Percentage hue)
     {
-        Throw.IfNegative(nameof(brightness), brightness);
-        Throw.IfNegative(nameof(saturation), saturation);
-        Throw.IfNegative(nameof(hue), hue);
-
         var modulate = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2}", brightness.ToDouble(), saturation.ToDouble(), hue.ToDouble());
 
         _nativeInstance.Modulate(modulate);
@@ -4698,14 +4674,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="percentageHighBlack">Defines the maximum black threshold value.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void RangeThreshold(Percentage percentageLowBlack, Percentage percentageLowWhite, Percentage percentageHighWhite, Percentage percentageHighBlack)
-    {
-        Throw.IfNegative(nameof(percentageLowBlack), percentageLowBlack);
-        Throw.IfNegative(nameof(percentageLowWhite), percentageLowWhite);
-        Throw.IfNegative(nameof(percentageHighWhite), percentageHighWhite);
-        Throw.IfNegative(nameof(percentageHighBlack), percentageHighBlack);
-
-        RangeThreshold(PercentageHelper.ToQuantumType(percentageLowBlack), PercentageHelper.ToQuantumType(percentageLowWhite), PercentageHelper.ToQuantumType(percentageHighWhite), PercentageHelper.ToQuantumType(percentageHighBlack));
-    }
+        => RangeThreshold(PercentageHelper.ToQuantumType(percentageLowBlack), PercentageHelper.ToQuantumType(percentageLowWhite), PercentageHelper.ToQuantumType(percentageHighWhite), PercentageHelper.ToQuantumType(percentageHighBlack));
 
     /// <summary>
     /// Applies soft and hard thresholding.
@@ -6908,11 +6877,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="channels">The channel(s) to make black.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void WhiteThreshold(Percentage threshold, Channels channels)
-    {
-        Throw.IfNegative(nameof(threshold), threshold);
-
-        _nativeInstance.WhiteThreshold(threshold.ToString(), channels);
-    }
+        => _nativeInstance.WhiteThreshold(threshold.ToString(), channels);
 
     /// <summary>
     /// Writes the image to the specified file.

--- a/src/Magick.NET/ResourceLimits.cs
+++ b/src/Magick.NET/ResourceLimits.cs
@@ -204,11 +204,7 @@ public partial class ResourceLimits : IResourceLimits
     /// </summary>
     /// <param name="percentage">The percentage to use.</param>
     public static void LimitMemory(Percentage percentage)
-    {
-        Throw.IfOutOfRange(nameof(percentage), percentage);
-
-        NativeResourceLimits.LimitMemory((double)percentage / 100.0);
-    }
+        => NativeResourceLimits.LimitMemory((double)percentage / 100.0);
 
     /// <summary>
     /// Set the maximum percentage of memory that can be used for image data. This also changes

--- a/src/Magick.NET/Types/MagickGeometry.cs
+++ b/src/Magick.NET/Types/MagickGeometry.cs
@@ -48,12 +48,7 @@ public sealed partial class MagickGeometry : IMagickGeometry
     /// <param name="percentageWidth">The percentage of the width.</param>
     /// <param name="percentageHeight">The percentage of the height.</param>
     public MagickGeometry(Percentage percentageWidth, Percentage percentageHeight)
-    {
-        Throw.IfNegative(nameof(percentageWidth), percentageWidth);
-        Throw.IfNegative(nameof(percentageHeight), percentageHeight);
-
-        InitializeFromPercentage(0, 0, (int)percentageWidth, (int)percentageHeight);
-    }
+        => InitializeFromPercentage(0, 0, (int)percentageWidth, (int)percentageHeight);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MagickGeometry"/> class using the specified offsets, width and height.
@@ -63,12 +58,7 @@ public sealed partial class MagickGeometry : IMagickGeometry
     /// <param name="percentageWidth">The percentage of the width.</param>
     /// <param name="percentageHeight">The percentage of the height.</param>
     public MagickGeometry(int x, int y, Percentage percentageWidth, Percentage percentageHeight)
-    {
-        Throw.IfNegative(nameof(percentageWidth), percentageWidth);
-        Throw.IfNegative(nameof(percentageHeight), percentageHeight);
-
-        InitializeFromPercentage(x, y, (int)percentageWidth, (int)percentageHeight);
-    }
+        => InitializeFromPercentage(x, y, (int)percentageWidth, (int)percentageHeight);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MagickGeometry"/> class using the specified geometry.

--- a/src/Shared/Throw.cs
+++ b/src/Shared/Throw.cs
@@ -73,6 +73,12 @@ internal static partial class Throw
             throw new ArgumentException("Value should not be negative.", paramName);
     }
 
+    public static void IfNegative(string paramName, double value)
+    {
+        if (value < 0.0)
+            throw new ArgumentException("Value should not be negative.", paramName);
+    }
+
     public static void IfNegative(string paramName, Percentage value)
     {
         if ((double)value < 0.0)

--- a/tests/Magick.NET.Core.Tests/Types/PercentageTests/TheConstructor.cs
+++ b/tests/Magick.NET.Core.Tests/Types/PercentageTests/TheConstructor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -10,6 +11,15 @@ public partial class PercentageTests
 {
     public class TheConstructor
     {
+        [Fact]
+        public void ShouldThrowExceptionWhenValueIsNegative()
+        {
+            Assert.Throws<ArgumentException>("value", () => new Percentage(-1.0));
+            Assert.Throws<ArgumentException>("value", () => (Percentage)(-1.0));
+            Assert.Throws<ArgumentException>("value", () => new Percentage(-1));
+            Assert.Throws<ArgumentException>("value", () => (Percentage)(-1));
+        }
+
         [Fact]
         public void ShouldDefaultToZero()
         {
@@ -29,13 +39,6 @@ public partial class PercentageTests
         {
             var percentage = new Percentage(200.0);
             Assert.Equal("200%", percentage.ToString());
-        }
-
-        [Fact]
-        public void ShouldHandleNegativeValue()
-        {
-            var percentage = new Percentage(-25);
-            Assert.Equal("-25%", percentage.ToString());
         }
     }
 }

--- a/tests/Magick.NET.Tests/Factories/MagickGeometryFactoryTests/TheCreateMethod.cs
+++ b/tests/Magick.NET.Tests/Factories/MagickGeometryFactoryTests/TheCreateMethod.cs
@@ -244,21 +244,5 @@ public partial class MagickGeometryFactoryTests
             Assert.Throws<ArgumentException>("height", () => factory.Create(5, -1));
             Assert.Throws<ArgumentException>("height", () => factory.Create(0, 0, 5, -1));
         }
-
-        [Fact]
-        public void ShouldThrowExceptionWhenPercentageWidthIsNegative()
-        {
-            var factory = new MagickGeometryFactory();
-
-            Assert.Throws<ArgumentException>("percentageWidth", () => factory.Create(new Percentage(-1), new Percentage(10)));
-        }
-
-        [Fact]
-        public void ShouldThrowExceptionWhenPercentageHeightIsNegative()
-        {
-            var factory = new MagickGeometryFactory();
-
-            Assert.Throws<ArgumentException>("percentageHeight", () => factory.Create(new Percentage(10), new Percentage(-1)));
-        }
     }
 }

--- a/tests/Magick.NET.Tests/MagickImageTests/TheColorizeMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheColorizeMethod.cs
@@ -22,14 +22,6 @@ public partial class MagickImageTests
             }
 
             [Fact]
-            public void ShouldThrowExceptionWhenPercentageIsNegative()
-            {
-                using var image = new MagickImage();
-
-                Assert.Throws<ArgumentException>("alpha", () => image.Colorize(MagickColors.Purple, new Percentage(-1)));
-            }
-
-            [Fact]
             public void ShouldColorizeTheImage()
             {
                 using var image = new MagickImage(Files.Builtin.Wizard);
@@ -47,30 +39,6 @@ public partial class MagickImageTests
                 using var image = new MagickImage();
 
                 Assert.Throws<ArgumentNullException>("color", () => image.Colorize(null, new Percentage(25), new Percentage(50), new Percentage(75)));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenAlphaRedIsNegative()
-            {
-                using var image = new MagickImage();
-
-                Assert.Throws<ArgumentException>("alphaRed", () => image.Colorize(MagickColors.Purple, new Percentage(-1), new Percentage(50), new Percentage(75)));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenAlphaGreenIsNegative()
-            {
-                using var image = new MagickImage();
-
-                Assert.Throws<ArgumentException>("alphaGreen", () => image.Colorize(MagickColors.Purple, new Percentage(25), new Percentage(-1), new Percentage(75)));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenAlphaBlueIsNegative()
-            {
-                using var image = new MagickImage();
-
-                Assert.Throws<ArgumentException>("alphaBlue", () => image.Colorize(MagickColors.Purple, new Percentage(25), new Percentage(50), new Percentage(-1)));
             }
 
             [Fact]

--- a/tests/Magick.NET.Tests/MagickImageTests/TheContrastStretchMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheContrastStretchMethod.cs
@@ -12,30 +12,6 @@ public partial class MagickImageTests
     public class TheContrastStretchMethod
     {
         [Fact]
-        public void ShouldThrowExceptionWhenPercentageIsNull()
-        {
-            using var image = new MagickImage();
-
-            Assert.Throws<ArgumentException>("blackPoint", () => image.ContrastStretch(new Percentage(-1)));
-        }
-
-        [Fact]
-        public void ShouldThrowExceptionWhenBlackPointIsNull()
-        {
-            using var image = new MagickImage();
-
-            Assert.Throws<ArgumentException>("blackPoint", () => image.ContrastStretch(new Percentage(-1), new Percentage(50)));
-        }
-
-        [Fact]
-        public void ShouldThrowExceptionWhenWhitePointIsNull()
-        {
-            using var image = new MagickImage();
-
-            Assert.Throws<ArgumentException>("whitePoint", () => image.ContrastStretch(new Percentage(50), new Percentage(-1)));
-        }
-
-        [Fact]
         public void ShouldImproveTheContrast()
         {
             using var image = new MagickImage(Files.Builtin.Wizard);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheDeskewMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheDeskewMethod.cs
@@ -20,26 +20,6 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShouldThrowExceptionWhenSettingsThresholdIsNegative()
-        {
-            var settings = new DeskewSettings
-            {
-                Threshold = new Percentage(-1),
-            };
-            using var image = new MagickImage();
-
-            Assert.Throws<ArgumentException>("settings", () => image.Deskew(settings));
-        }
-
-        [Fact]
-        public void ShouldThrowExceptionWhenThresholdIsNegative()
-        {
-            using var image = new MagickImage();
-
-            Assert.Throws<ArgumentException>("settings", () => image.Deskew(new Percentage(-1)));
-        }
-
-        [Fact]
         public void ShouldDeskewTheImage()
         {
             using var image = new MagickImage(Files.LetterJPG);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheInterpolativeResizeMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheInterpolativeResizeMethod.cs
@@ -26,27 +26,6 @@ public partial class MagickImageTests
         }
 
         [Fact]
-        public void ShouldThrowExceptionWhenPercentageIsNegative()
-        {
-            using var image = new MagickImage(Files.RedPNG);
-            Assert.Throws<ArgumentException>("percentageWidth", () => image.InterpolativeResize(new Percentage(-1), PixelInterpolateMethod.Mesh));
-        }
-
-        [Fact]
-        public void ShouldThrowExceptionWhenPercentageWidthIsNegative()
-        {
-            using var image = new MagickImage(Files.RedPNG);
-            Assert.Throws<ArgumentException>("percentageWidth", () => image.InterpolativeResize(new Percentage(-1), new Percentage(10), PixelInterpolateMethod.Mesh));
-        }
-
-        [Fact]
-        public void ShouldThrowExceptionWhenPercentageHeightIsNegative()
-        {
-            using var image = new MagickImage(Files.RedPNG);
-            Assert.Throws<ArgumentException>("percentageHeight", () => image.InterpolativeResize(new Percentage(10), new Percentage(-1), PixelInterpolateMethod.Mesh));
-        }
-
-        [Fact]
         public void ShouldResizeTheImage()
         {
             using var image = new MagickImage(Files.RedPNG);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheLiquidRescaleMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheLiquidRescaleMethod.cs
@@ -100,32 +100,6 @@ public partial class MagickImageTests
         public class WithPercentage
         {
             [Fact]
-            public void ShouldThrowExceptionWhenPercentageIsNegative()
-            {
-                var percentage = new Percentage(-1);
-                using var image = new MagickImage(Files.MagickNETIconPNG);
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.LiquidRescale(percentage));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageWidthIsNegative()
-            {
-                var percentageWidth = new Percentage(-1);
-                var percentageHeight = new Percentage(1);
-                using var image = new MagickImage(Files.MagickNETIconPNG);
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.LiquidRescale(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageHeightIsNegative()
-            {
-                var percentageWidth = new Percentage(1);
-                var percentageHeight = new Percentage(-1);
-                using var image = new MagickImage(Files.MagickNETIconPNG);
-                Assert.Throws<ArgumentException>("percentageHeight", () => image.LiquidRescale(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
             public void ShouldResizeTheImage()
             {
                 using var image = new MagickImage(Files.MagickNETIconPNG);
@@ -148,22 +122,6 @@ public partial class MagickImageTests
 
         public class WithPercentageAndRigidity
         {
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageWidthIsNegative()
-            {
-                using var image = new MagickImage(Files.MagickNETIconPNG);
-
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.LiquidRescale(new Percentage(-1), new Percentage(1), 0.0, 0.0));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageHeightIsNegative()
-            {
-                using var image = new MagickImage(Files.MagickNETIconPNG);
-
-                Assert.Throws<ArgumentException>("percentageHeight", () => image.LiquidRescale(new Percentage(1), new Percentage(-1), 0.0, 0.0));
-            }
-
             [Fact]
             public void ShouldApplyTheRigidity()
             {

--- a/tests/Magick.NET.Tests/MagickImageTests/TheRangeThresholdMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheRangeThresholdMethod.cs
@@ -24,38 +24,6 @@ public partial class MagickImageTests
         public class WithPercentage
         {
             [Fact]
-            public void ShouldThrowExceptionWhenLowBlackIsNegative()
-            {
-                using var image = new MagickImage(MagickColors.Red, 1, 1);
-
-                Assert.Throws<ArgumentException>("percentageLowBlack", () => image.RangeThreshold(new Percentage(-1), new Percentage(0), new Percentage(0), new Percentage(0)));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenLowWhiteIsNegative()
-            {
-                using var image = new MagickImage(MagickColors.Red, 1, 1);
-
-                Assert.Throws<ArgumentException>("percentageLowWhite", () => image.RangeThreshold(new Percentage(0), new Percentage(-1), new Percentage(0), new Percentage(0)));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenHighWhiteIsNegative()
-            {
-                using var image = new MagickImage(MagickColors.Red, 1, 1);
-
-                Assert.Throws<ArgumentException>("percentageHighWhite", () => image.RangeThreshold(new Percentage(0), new Percentage(0), new Percentage(-1), new Percentage(0)));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenHighBlackIsNegative()
-            {
-                using var image = new MagickImage(MagickColors.Red, 1, 1);
-
-                Assert.Throws<ArgumentException>("percentageHighBlack", () => image.RangeThreshold(new Percentage(0), new Percentage(0), new Percentage(0), new Percentage(-1)));
-            }
-
-            [Fact]
             public void ShouldChangeTheImage()
             {
                 using var image = new MagickImage("gradient:", 50, 256);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheResizeMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheResizeMethod.cs
@@ -94,35 +94,6 @@ public partial class MagickImageTests
         public class WithPercentage
         {
             [Fact]
-            public void ShouldThrowExceptionWhenPercentageIsNegative()
-            {
-                var percentage = new Percentage(-0.5);
-                using var image = new MagickImage(Files.MagickNETIconPNG);
-
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.Resize(percentage));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageWidthIsNegative()
-            {
-                var percentageWidth = new Percentage(-0.5);
-                var percentageHeight = new Percentage(10);
-                using var image = new MagickImage(Files.MagickNETIconPNG);
-
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.Resize(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageHeightIsNegative()
-            {
-                var percentageWidth = new Percentage(10);
-                var percentageHeight = new Percentage(-0.5);
-                using var image = new MagickImage(Files.MagickNETIconPNG);
-
-                Assert.Throws<ArgumentException>("percentageHeight", () => image.Resize(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
             public void ShouldResizeTheImage()
             {
                 using var image = new MagickImage(Files.MagickNETIconPNG);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheSampleMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheSampleMethod.cs
@@ -62,35 +62,6 @@ public partial class MagickImageTests
         public class WithPercentage
         {
             [Fact]
-            public void ShouldThrowExceptionWhenPercentageIsNegative()
-            {
-                var percentage = new Percentage(-0.5);
-                using var image = new MagickImage(Files.Builtin.Logo);
-
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.Sample(percentage));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageWidthIsNegative()
-            {
-                var percentageWidth = new Percentage(-0.5);
-                var percentageHeight = new Percentage(10);
-                using var image = new MagickImage(Files.Builtin.Logo);
-
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.Sample(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageHeightIsNegative()
-            {
-                var percentageWidth = new Percentage(10);
-                var percentageHeight = new Percentage(-0.5);
-                using var image = new MagickImage(Files.Builtin.Logo);
-
-                Assert.Throws<ArgumentException>("percentageHeight", () => image.Sample(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
             public void ShouldUseTheSpecifiedPercentage()
             {
                 using var image = new MagickImage(Files.Builtin.Logo);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheScaleMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheScaleMethod.cs
@@ -62,35 +62,6 @@ public partial class MagickImageTests
         public class WithPercentage
         {
             [Fact]
-            public void ShouldThrowExceptionWhenPercentageIsNegative()
-            {
-                var percentage = new Percentage(-0.5);
-                using var image = new MagickImage(Files.Builtin.Logo);
-
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.Scale(percentage));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageWidthIsNegative()
-            {
-                var percentageWidth = new Percentage(-0.5);
-                var percentageHeight = new Percentage(10);
-                using var image = new MagickImage(Files.Builtin.Logo);
-
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.Scale(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageHeightIsNegative()
-            {
-                var percentageWidth = new Percentage(10);
-                var percentageHeight = new Percentage(-0.5);
-                using var image = new MagickImage(Files.Builtin.Logo);
-
-                Assert.Throws<ArgumentException>("percentageHeight", () => image.Scale(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
             public void ShouldUseTheSpecifiedPercentage()
             {
                 using var image = new MagickImage(Files.Builtin.Logo);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheThumbnailMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheThumbnailMethod.cs
@@ -62,32 +62,6 @@ public partial class MagickImageTests
         public class WithPercentage
         {
             [Fact]
-            public void ShouldThrowExceptionWhenPercentageIsNegative()
-            {
-                var percentage = new Percentage(-0.5);
-                using var image = new MagickImage();
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.Thumbnail(percentage));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageWidthIsNegative()
-            {
-                var percentageWidth = new Percentage(-0.5);
-                var percentageHeight = new Percentage(10);
-                using var image = new MagickImage();
-                Assert.Throws<ArgumentException>("percentageWidth", () => image.Thumbnail(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
-            public void ShouldThrowExceptionWhenPercentageHeightIsNegative()
-            {
-                var percentageWidth = new Percentage(10);
-                var percentageHeight = new Percentage(-0.5);
-                using var image = new MagickImage();
-                Assert.Throws<ArgumentException>("percentageHeight", () => image.Thumbnail(percentageWidth, percentageHeight));
-            }
-
-            [Fact]
             public void ShouldCreateThumbnailOfTheImageWithTheSpecifiedPercentage()
             {
                 using var image = new MagickImage(Files.Builtin.Logo);

--- a/tests/Magick.NET.Tests/ResourceLimitsTests/TheLimitMemoryMethod.cs
+++ b/tests/Magick.NET.Tests/ResourceLimitsTests/TheLimitMemoryMethod.cs
@@ -13,12 +13,6 @@ public partial class ResourceLimitsTests
     public class TheLimitMemoryMethod
     {
         [Fact]
-        public void ShouldThrowExceptionWhenValueIsTooHigh()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>("percentage", () => ResourceLimits.LimitMemory(new Percentage(100.1)));
-        }
-
-        [Fact]
         public void ShouldChangeAreaAndMemory()
         {
             var area = ResourceLimits.Area;

--- a/tests/Magick.NET.Tests/ResourceLimitsTests/TheLimitMemoryMethod.cs
+++ b/tests/Magick.NET.Tests/ResourceLimitsTests/TheLimitMemoryMethod.cs
@@ -13,12 +13,6 @@ public partial class ResourceLimitsTests
     public class TheLimitMemoryMethod
     {
         [Fact]
-        public void ShouldThrowExceptionWhenValueIsNegative()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>("percentage", () => ResourceLimits.LimitMemory(new Percentage(-0.99)));
-        }
-
-        [Fact]
         public void ShouldThrowExceptionWhenValueIsTooHigh()
         {
             Assert.Throws<ArgumentOutOfRangeException>("percentage", () => ResourceLimits.LimitMemory(new Percentage(100.1)));


### PR DESCRIPTION
:wave: 

As discussed https://github.com/dlemstra/Magick.NET/discussions/1568#discussioncomment-8635702, this PR make Percentage positive only (including zero).

Therefore:
- all guards checking if percentage value is negative has been removed
- all tests where `Percentage` was initialized with negative value has been removed

Regards.