### PR TITLE
fix: add guards for MagickImage.SetBitDepth

### DIFF
--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -5784,7 +5784,11 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="channels">The channel to set the depth for.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void SetBitDepth(int value, Channels channels)
-        => _nativeInstance.SetBitDepth(value, channels);
+    {
+        Throw.IfNegative(nameof(value), value);
+
+        _nativeInstance.SetBitDepth(value, channels);
+    }
 
     /// <summary>
     /// Sets the default clipping path.

--- a/tests/Magick.NET.Tests/MagickImageTests/TheSetBitDepthMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheSetBitDepthMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -10,6 +11,14 @@ public partial class MagickImageTests
 {
     public class TheSetBitDepthMethod
     {
+        [Fact]
+        public void ShouldThrowExceptionWhenValueIsNegative()
+        {
+            using var image = new MagickImage(Files.RoseSparkleGIF);
+
+            Assert.Throws<ArgumentException>("value", () => image.SetBitDepth(-1));
+        }
+
         [Fact]
         public void ShouldChangeTheBitDepth()
         {


### PR DESCRIPTION
:wave:

* https://github.com/ImageMagick/ImageMagick/blob/0deac72ed480ac2ec8e9d766c15ddb3bca055952/MagickCore/attribute.h#L38 requires `size_t` for `depth`
* https://github.com/dlemstra/Magick.Native/blob/8861d8354cad042aa39e0daed47f70327cba03f5/src/Magick.Native/MagickImage.c#L2203-L2210 requires `size_t` for `value`
* no checks done on binding, except casting to UInt (so >= 0) https://github.com/dlemstra/Magick.NET/blob/e49ebfe1fc238bb985855ea5d4b9eae6c06eb646/src/Magick.NET/Native/MagickImage.cs#L7550-L7572

Regards 🙂