### PR TITLE
fix: add guards for MagickImage.Statistic

### DIFF
--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -6252,7 +6252,12 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="height">The height of the pixel neighborhood.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Statistic(StatisticType type, int width, int height)
-        => _nativeInstance.Statistic(type, width, height);
+    {
+        Throw.IfNegative(nameof(width), width);
+        Throw.IfNegative(nameof(height), height);
+
+        _nativeInstance.Statistic(type, width, height);
+    }
 
     /// <summary>
     /// Returns the image statistics.

--- a/tests/Magick.NET.Tests/MagickImageTests/TheStatisticMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheStatisticMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -10,6 +11,22 @@ public partial class MagickImageTests
 {
     public class TheStatisticMethod
     {
+        [Fact]
+        public void ShouldThrowExceptionWhenWidthIsNegative()
+        {
+            using var image = new MagickImage(Files.NoisePNG);
+
+            Assert.Throws<ArgumentException>("width", () => image.Statistic(StatisticType.Minimum, -1, 1));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenHeightIsNegative()
+        {
+            using var image = new MagickImage(Files.NoisePNG);
+
+            Assert.Throws<ArgumentException>("height", () => image.Statistic(StatisticType.Minimum, 10, -1));
+        }
+
         [Fact]
         public void ShouldChangePixels()
         {


### PR DESCRIPTION
:wave:

Same as usual 😅 : adding guards to prevent negative parameters.

Regards.