### PR TITLE
add orientation to MagickImageInfo

### DIFF
--- a/src/Magick.NET.Core/IMagickImageInfo.cs
+++ b/src/Magick.NET.Core/IMagickImageInfo.cs
@@ -56,6 +56,11 @@ public partial interface IMagickImageInfo
     int Width { get; }
 
     /// <summary>
+    /// Gets the orientation of the image.
+    /// </summary>
+    OrientationType Orientation { get; }
+
+    /// <summary>
     /// Read basic information about an image.
     /// </summary>
     /// <param name="data">The byte array to read the information from.</param>

--- a/src/Magick.NET/MagickImageInfo.cs
+++ b/src/Magick.NET/MagickImageInfo.cs
@@ -178,6 +178,11 @@ public sealed partial class MagickImageInfo : IMagickImageInfo<QuantumType>
     public int Width { get; private set; }
 
     /// <summary>
+    /// Gets the orientation of the image.
+    /// </summary>
+    public OrientationType Orientation { get; private set; }
+
+    /// <summary>
     /// Read basic information about an image with multiple frames/pages.
     /// </summary>
     /// <param name="data">The byte array to read the information from.</param>
@@ -439,5 +444,6 @@ public sealed partial class MagickImageInfo : IMagickImageInfo<QuantumType>
         Interlace = image.Interlace;
         Quality = image.Quality;
         Width = image.Width;
+        Orientation = image.Orientation;
     }
 }

--- a/tests/Magick.NET.Tests/MagickImageInfoTests/TheReadCollectionMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageInfoTests/TheReadCollectionMethod.cs
@@ -119,6 +119,7 @@ public partial class MagickImageInfoTests
                 Assert.Equal(Interlace.NoInterlace, first.Interlace);
                 Assert.Equal(827, first.Width);
                 Assert.Equal(0, first.Quality);
+                Assert.Equal(OrientationType.TopLeft, first.Orientation);
             }
         }
 

--- a/tests/Magick.NET.Tests/MagickImageInfoTests/TheReadMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageInfoTests/TheReadMethod.cs
@@ -134,6 +134,7 @@ public partial class MagickImageInfoTests
                 Assert.Equal(Interlace.NoInterlace, imageInfo.Interlace);
                 Assert.Equal(100, imageInfo.Quality);
                 Assert.Equal(123, imageInfo.Width);
+                Assert.Equal(OrientationType.Undefined, imageInfo.Orientation);
             }
         }
 


### PR DESCRIPTION
### Description

Orientation is a useful piece of information to have about an image and can be added very simply / at no extra cost to IMagickImageInfo

This pull request adds an Orientation property to IMagickImageInfo/MagickImageInfo. The code follows the same pattern as the other properties on IMagickImageInfo. 