### PR TITLE
clean: make QuantizeSettings.CreateInstance parameter non nullable

### DIFF
--- a/src/Magick.NET/Native/Settings/QuantizeSettings.cs
+++ b/src/Magick.NET/Native/Settings/QuantizeSettings.cs
@@ -232,10 +232,8 @@ public partial class QuantizeSettings
             #endif
         }
     }
-    internal static INativeInstance CreateInstance(IQuantizeSettings? instance)
+    internal static INativeInstance CreateInstance(IQuantizeSettings instance)
     {
-        if (instance is null)
-            return NativeInstance.Zero;
         return QuantizeSettings.CreateNativeInstance(instance);
     }
 }


### PR DESCRIPTION
:wave: 

It seems that this method is only invoked with non-null parameter.

https://github.com/dlemstra/Magick.NET/blob/32edbce1143c06a256d80384982dfb7d0a7cf010/src/Magick.NET/Native/Settings/QuantizeSettings.cs#L235-L240


This PR remove nullable possibility of parameter.

Regards.