### PR TITLE
fix: add guard for MagickImage.Morphology

### DIFF
--- a/src/Magick.NET.Core/IMagickImage.cs
+++ b/src/Magick.NET.Core/IMagickImage.cs
@@ -2163,7 +2163,7 @@ public partial interface IMagickImage : IDisposable
     /// <param name="method">The morphology method.</param>
     /// <param name="kernel">Built-in kernel.</param>
     /// <param name="channels">The channels to apply the kernel to.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void Morphology(MorphologyMethod method, Kernel kernel, Channels channels, int iterations);
 
@@ -2172,7 +2172,7 @@ public partial interface IMagickImage : IDisposable
     /// </summary>
     /// <param name="method">The morphology method.</param>
     /// <param name="kernel">Built-in kernel.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void Morphology(MorphologyMethod method, Kernel kernel, int iterations);
 
@@ -2202,7 +2202,7 @@ public partial interface IMagickImage : IDisposable
     /// <param name="kernel">Built-in kernel.</param>
     /// <param name="arguments">Kernel arguments.</param>
     /// <param name="channels">The channels to apply the kernel to.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void Morphology(MorphologyMethod method, Kernel kernel, string? arguments, Channels channels, int iterations);
 
@@ -2212,7 +2212,7 @@ public partial interface IMagickImage : IDisposable
     /// <param name="method">The morphology method.</param>
     /// <param name="kernel">Built-in kernel.</param>
     /// <param name="arguments">Kernel arguments.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void Morphology(MorphologyMethod method, Kernel kernel, string? arguments, int iterations);
 
@@ -2239,7 +2239,7 @@ public partial interface IMagickImage : IDisposable
     /// <param name="method">The morphology method.</param>
     /// <param name="userKernel">User suplied kernel.</param>
     /// <param name="channels">The channels to apply the kernel to.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void Morphology(MorphologyMethod method, string userKernel, Channels channels, int iterations);
 
@@ -2248,7 +2248,7 @@ public partial interface IMagickImage : IDisposable
     /// </summary>
     /// <param name="method">The morphology method.</param>
     /// <param name="userKernel">User suplied kernel.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void Morphology(MorphologyMethod method, string userKernel, int iterations);
 

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -4231,7 +4231,11 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="iterations">The number of iterations.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Morphology(MorphologyMethod method, string userKernel, Channels channels, int iterations)
-        => _nativeInstance.Morphology(method, userKernel, channels, iterations);
+    {
+        Throw.IfTrue(nameof(iterations), iterations < -1, "The number of iterations must be unlimited (-1) or positive");
+
+        _nativeInstance.Morphology(method, userKernel, channels, iterations);
+    }
 
     /// <summary>
     /// Applies a kernel to the image according to the given mophology method.

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -4140,7 +4140,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="method">The morphology method.</param>
     /// <param name="kernel">Built-in kernel.</param>
     /// <param name="channels">The channels to apply the kernel to.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Morphology(MorphologyMethod method, Kernel kernel, Channels channels, int iterations)
         => Morphology(method, kernel, string.Empty, channels, iterations);
@@ -4150,7 +4150,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// </summary>
     /// <param name="method">The morphology method.</param>
     /// <param name="kernel">Built-in kernel.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Morphology(MorphologyMethod method, Kernel kernel, int iterations)
         => Morphology(method, kernel, string.Empty, ImageMagick.Channels.Undefined, iterations);
@@ -4183,7 +4183,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="kernel">Built-in kernel.</param>
     /// <param name="arguments">Kernel arguments.</param>
     /// <param name="channels">The channels to apply the kernel to.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Morphology(MorphologyMethod method, Kernel kernel, string? arguments, Channels channels, int iterations)
     {
@@ -4198,7 +4198,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="method">The morphology method.</param>
     /// <param name="kernel">Built-in kernel.</param>
     /// <param name="arguments">Kernel arguments.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Morphology(MorphologyMethod method, Kernel kernel, string? arguments, int iterations)
         => Morphology(method, kernel, arguments, ImageMagick.Channels.Undefined, iterations);
@@ -4228,7 +4228,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <param name="method">The morphology method.</param>
     /// <param name="userKernel">User suplied kernel.</param>
     /// <param name="channels">The channels to apply the kernel to.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Morphology(MorphologyMethod method, string userKernel, Channels channels, int iterations)
     {
@@ -4242,7 +4242,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// </summary>
     /// <param name="method">The morphology method.</param>
     /// <param name="userKernel">User suplied kernel.</param>
-    /// <param name="iterations">The number of iterations.</param>
+    /// <param name="iterations">The number of iterations. A value of -1 means loop until no change found.</param>
     /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void Morphology(MorphologyMethod method, string userKernel, int iterations)
         => Morphology(method, userKernel, ImageMagick.Channels.Undefined, iterations);

--- a/tests/Magick.NET.Tests/MagickImageTests/TheMorphologyMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheMorphologyMethod.cs
@@ -39,6 +39,16 @@ public partial class MagickImageTests
         }
 
         [Fact]
+        public void ShouldThrowExceptionWhenIterationsIsLowerThanMinusOne()
+        {
+            using var image = new MagickImage();
+            var settings = new MorphologySettings();
+            settings.Iterations = -2;
+
+            Assert.Throws<ArgumentException>("iterations", () => image.Morphology(settings));
+        }
+
+        [Fact]
         public void ShouldUseTheSpecifiedSettings()
         {
             using var image = new MagickImage(Files.Builtin.Logo);


### PR DESCRIPTION
### Description

:wave: 

I had to take a look at [ImageMagick source code](https://github.com/ImageMagick/ImageMagick/blob/80b7ad564764ee0a24994c4c2feabf145a3eeb89/MagickCore/morphology.c#L4118-L4121) to understand why `MagickImage.Morphology`'s `iterations` parameter can be negative.

So this PR add both a guard and update documentation for the parameter.

Regards.