### PR TITLE
perf: use index access to Dictionary

### DIFF
--- a/src/Magick.NET.Core/Statistics/IMoments.cs
+++ b/src/Magick.NET.Core/Statistics/IMoments.cs
@@ -12,12 +12,12 @@ public interface IMoments
     /// Gets the moments for the all the channels.
     /// </summary>
     /// <returns>The moments for the all the channels.</returns>
-    IChannelMoments Composite();
+    IChannelMoments? Composite();
 
     /// <summary>
     /// Gets the moments for the specified channel.
     /// </summary>
     /// <param name="channel">The channel to get the moments for.</param>
     /// <returns>The moments for the specified channel.</returns>
-    IChannelMoments GetChannel(PixelChannel channel);
+    IChannelMoments? GetChannel(PixelChannel channel);
 }

--- a/src/Magick.NET.Core/Statistics/IPerceptualHash.cs
+++ b/src/Magick.NET.Core/Statistics/IPerceptualHash.cs
@@ -13,7 +13,7 @@ public interface IPerceptualHash
     /// </summary>
     /// <param name="channel">The channel to get the has for.</param>
     /// <returns>The perceptual hash for the specified channel.</returns>
-    IChannelPerceptualHash GetChannel(PixelChannel channel);
+    IChannelPerceptualHash? GetChannel(PixelChannel channel);
 
     /// <summary>
     /// Returns the sum squared difference between this hash and the other hash.

--- a/src/Magick.NET/Statistics/Moments.cs
+++ b/src/Magick.NET/Statistics/Moments.cs
@@ -29,15 +29,18 @@ public sealed partial class Moments : IMoments
     /// </summary>
     /// <returns>The moments for the all the channels.</returns>
     public IChannelMoments Composite()
-        => GetChannel(PixelChannel.Composite);
+        => _channels[PixelChannel.Composite];
 
     /// <summary>
     /// Gets the moments for the specified channel.
     /// </summary>
     /// <param name="channel">The channel to get the moments for.</param>
     /// <returns>The moments for the specified channel.</returns>
-    public IChannelMoments GetChannel(PixelChannel channel)
-        => _channels[channel];
+    public IChannelMoments? GetChannel(PixelChannel channel)
+    {
+        _channels.TryGetValue(channel, out var moments);
+        return moments;
+    }
 
     internal static void DisposeList(IntPtr list)
     {

--- a/src/Magick.NET/Statistics/Moments.cs
+++ b/src/Magick.NET/Statistics/Moments.cs
@@ -37,10 +37,7 @@ public sealed partial class Moments : IMoments
     /// <param name="channel">The channel to get the moments for.</param>
     /// <returns>The moments for the specified channel.</returns>
     public IChannelMoments GetChannel(PixelChannel channel)
-    {
-        _channels.TryGetValue(channel, out var moments);
-        return moments;
-    }
+        => _channels[channel];
 
     internal static void DisposeList(IntPtr list)
     {

--- a/src/Magick.NET/Statistics/PerceptualHash.cs
+++ b/src/Magick.NET/Statistics/PerceptualHash.cs
@@ -82,7 +82,7 @@ public sealed partial class PerceptualHash : IPerceptualHash
         var green = other.GetChannel(PixelChannel.Green);
         var blue = other.GetChannel(PixelChannel.Blue);
 
-        if (red == null || green == null || blue == null)
+        if (red is null || green is null || blue is null)
         {
             throw new NotSupportedException("other IPerceptualHash must have Red, Green and Blue channel");
         }

--- a/src/Magick.NET/Statistics/PerceptualHash.cs
+++ b/src/Magick.NET/Statistics/PerceptualHash.cs
@@ -79,16 +79,18 @@ public sealed partial class PerceptualHash : IPerceptualHash
         Throw.IfNull(nameof(other), other);
 
         var red = other.GetChannel(PixelChannel.Red);
-        Throw.IfNull(nameof(red), other, "other hash does not have a Red channel");
         var green = other.GetChannel(PixelChannel.Green);
-        Throw.IfNull(nameof(red), other, "other hash does not have a Green channel");
         var blue = other.GetChannel(PixelChannel.Blue);
-        Throw.IfNull(nameof(red), other, "other hash does not have a Blue channel");
+
+        if (red == null || green == null || blue == null)
+        {
+            throw new NotSupportedException("other IPerceptualHash must have Red, Green and Blue channel");
+        }
 
         return
-          _channels[PixelChannel.Red].SumSquaredDistance(red!) +
-          _channels[PixelChannel.Green].SumSquaredDistance(green!) +
-          _channels[PixelChannel.Blue].SumSquaredDistance(blue!);
+          _channels[PixelChannel.Red].SumSquaredDistance(red) +
+          _channels[PixelChannel.Green].SumSquaredDistance(green) +
+          _channels[PixelChannel.Blue].SumSquaredDistance(blue);
     }
 
     /// <summary>

--- a/src/Magick.NET/Statistics/PerceptualHash.cs
+++ b/src/Magick.NET/Statistics/PerceptualHash.cs
@@ -63,8 +63,11 @@ public sealed partial class PerceptualHash : IPerceptualHash
     /// </summary>
     /// <param name="channel">The channel to get the has for.</param>
     /// <returns>The perceptual hash for the specified channel.</returns>
-    public IChannelPerceptualHash GetChannel(PixelChannel channel)
-        => _channels[channel];
+    public IChannelPerceptualHash? GetChannel(PixelChannel channel)
+    {
+        _channels.TryGetValue(channel, out var perceptualHash);
+        return perceptualHash;
+    }
 
     /// <summary>
     /// Returns the sum squared difference between this hash and the other hash.
@@ -75,10 +78,17 @@ public sealed partial class PerceptualHash : IPerceptualHash
     {
         Throw.IfNull(nameof(other), other);
 
+        var red = other.GetChannel(PixelChannel.Red);
+        Throw.IfNull(nameof(red), other, "other hash does not have a Red channel");
+        var green = other.GetChannel(PixelChannel.Green);
+        Throw.IfNull(nameof(red), other, "other hash does not have a Green channel");
+        var blue = other.GetChannel(PixelChannel.Blue);
+        Throw.IfNull(nameof(red), other, "other hash does not have a Blue channel");
+
         return
-          _channels[PixelChannel.Red].SumSquaredDistance(other.GetChannel(PixelChannel.Red)) +
-          _channels[PixelChannel.Green].SumSquaredDistance(other.GetChannel(PixelChannel.Green)) +
-          _channels[PixelChannel.Blue].SumSquaredDistance(other.GetChannel(PixelChannel.Blue));
+          _channels[PixelChannel.Red].SumSquaredDistance(red!) +
+          _channels[PixelChannel.Green].SumSquaredDistance(green!) +
+          _channels[PixelChannel.Blue].SumSquaredDistance(blue!);
     }
 
     /// <summary>

--- a/src/Magick.NET/Statistics/PerceptualHash.cs
+++ b/src/Magick.NET/Statistics/PerceptualHash.cs
@@ -64,10 +64,7 @@ public sealed partial class PerceptualHash : IPerceptualHash
     /// <param name="channel">The channel to get the has for.</param>
     /// <returns>The perceptual hash for the specified channel.</returns>
     public IChannelPerceptualHash GetChannel(PixelChannel channel)
-    {
-        _channels.TryGetValue(channel, out var perceptualHash);
-        return perceptualHash;
-    }
+        => _channels[channel];
 
     /// <summary>
     /// Returns the sum squared difference between this hash and the other hash.

--- a/tests/Magick.NET.Tests/Statistics/MomentsTests/TheGetChannelMethod.cs
+++ b/tests/Magick.NET.Tests/Statistics/MomentsTests/TheGetChannelMethod.cs
@@ -11,7 +11,7 @@ public partial class MomentsTests
     public class TheGetChannelMethod
     {
         [Fact]
-        public void ShouldThrowExceptionWhenChannelDoesNotExist()
+        public void ShouldReturnNullWhenChannelDoesNotExist()
         {
             using var image = new MagickImage(Files.ImageMagickJPG);
             var moments = image.Moments();

--- a/tests/Magick.NET.Tests/Statistics/MomentsTests/TheGetChannelMethod.cs
+++ b/tests/Magick.NET.Tests/Statistics/MomentsTests/TheGetChannelMethod.cs
@@ -1,7 +1,6 @@
 // Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Collections.Generic;
 using ImageMagick;
 using Xunit;
 
@@ -21,7 +20,7 @@ public partial class MomentsTests
             Assert.NotNull(moments.GetChannel(PixelChannel.Green));
             Assert.NotNull(moments.GetChannel(PixelChannel.Blue));
 
-            Assert.Throws<KeyNotFoundException>(() => moments.GetChannel(PixelChannel.Black));
+            Assert.Null(moments.GetChannel(PixelChannel.Black));
         }
     }
 }

--- a/tests/Magick.NET.Tests/Statistics/MomentsTests/TheGetChannelMethod.cs
+++ b/tests/Magick.NET.Tests/Statistics/MomentsTests/TheGetChannelMethod.cs
@@ -1,0 +1,27 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using ImageMagick;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class MomentsTests
+{
+    public class TheGetChannelMethod
+    {
+        [Fact]
+        public void ShouldThrowExceptionWhenChannelDoesNotExist()
+        {
+            using var image = new MagickImage(Files.ImageMagickJPG);
+            var moments = image.Moments();
+
+            Assert.NotNull(moments.GetChannel(PixelChannel.Red));
+            Assert.NotNull(moments.GetChannel(PixelChannel.Green));
+            Assert.NotNull(moments.GetChannel(PixelChannel.Blue));
+
+            Assert.Throws<KeyNotFoundException>(() => moments.GetChannel(PixelChannel.Black));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheGetChannelMethod.cs
+++ b/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheGetChannelMethod.cs
@@ -1,0 +1,26 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using ImageMagick;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PerceptualHashTests
+{
+    public class TheGetChannelMethod
+    {
+        [Fact]
+        public void ShouldThrowExceptionWhenChannelDoesNotExist()
+        {
+            var hash = new PerceptualHash("81b4488652898d48a7a9622346206e620f8a646682939835e986ec98c78f887ae8c67f81b1e884c58a0d18af2d622718fd35623ffdeac9a78cbaedaa81d888434e824c683ad781c37895978c8688c426628ed61b216279b81b48887318a1628af43622a2619d162372");
+
+            Assert.NotNull(hash.GetChannel(PixelChannel.Red));
+            Assert.NotNull(hash.GetChannel(PixelChannel.Green));
+            Assert.NotNull(hash.GetChannel(PixelChannel.Blue));
+
+            Assert.Throws<KeyNotFoundException>(() => hash.GetChannel(PixelChannel.Black));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheGetChannelMethod.cs
+++ b/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheGetChannelMethod.cs
@@ -11,7 +11,7 @@ public partial class PerceptualHashTests
     public class TheGetChannelMethod
     {
         [Fact]
-        public void ShouldThrowExceptionWhenChannelDoesNotExist()
+        public void ShouldReturnNullWhenChannelDoesNotExist()
         {
             var hash = new PerceptualHash("81b4488652898d48a7a9622346206e620f8a646682939835e986ec98c78f887ae8c67f81b1e884c58a0d18af2d622718fd35623ffdeac9a78cbaedaa81d888434e824c683ad781c37895978c8688c426628ed61b216279b81b48887318a1628af43622a2619d162372");
 

--- a/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheGetChannelMethod.cs
+++ b/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheGetChannelMethod.cs
@@ -1,7 +1,6 @@
 // Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Collections.Generic;
 using ImageMagick;
 using Xunit;
 
@@ -20,7 +19,7 @@ public partial class PerceptualHashTests
             Assert.NotNull(hash.GetChannel(PixelChannel.Green));
             Assert.NotNull(hash.GetChannel(PixelChannel.Blue));
 
-            Assert.Throws<KeyNotFoundException>(() => hash.GetChannel(PixelChannel.Black));
+            Assert.Null(hash.GetChannel(PixelChannel.Black));
         }
     }
 }

--- a/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheSumSquaredDistanceMethod.cs
+++ b/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheSumSquaredDistanceMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using ImageMagick;
 using Xunit;
 
@@ -8,8 +9,30 @@ namespace Magick.NET.Tests;
 
 public partial class PerceptualHashTests
 {
+    public class TestPerceptualHash : IPerceptualHash
+    {
+        public IChannelPerceptualHash GetChannel(PixelChannel channel)
+        {
+            return null;
+        }
+
+        public double SumSquaredDistance(IPerceptualHash other)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
     public class TheSumSquaredDistanceMethod
     {
+        [Fact]
+        public void ShouldThrowNotSupportedExceptionIfCustomImplementationDoesNotHaveExpectedChannels()
+        {
+            using var image = new MagickImage(Files.ImageMagickJPG);
+            var phash = image.PerceptualHash();
+
+            Assert.Throws<NotSupportedException>(() => phash.SumSquaredDistance(new TestPerceptualHash()));
+        }
+
         [Fact]
         public void ShouldReturnTheDifference()
         {

--- a/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheSumSquaredDistanceMethod.cs
+++ b/tests/Magick.NET.Tests/Statistics/PerceptualHashTests/TheSumSquaredDistanceMethod.cs
@@ -12,9 +12,7 @@ public partial class PerceptualHashTests
     public class TestPerceptualHash : IPerceptualHash
     {
         public IChannelPerceptualHash GetChannel(PixelChannel channel)
-        {
-            return null;
-        }
+            => null;
 
         public double SumSquaredDistance(IPerceptualHash other)
         {
@@ -29,8 +27,10 @@ public partial class PerceptualHashTests
         {
             using var image = new MagickImage(Files.ImageMagickJPG);
             var phash = image.PerceptualHash();
+            Assert.NotNull(phash);
 
-            Assert.Throws<NotSupportedException>(() => phash.SumSquaredDistance(new TestPerceptualHash()));
+            var exception = Assert.Throws<NotSupportedException>(() => phash.SumSquaredDistance(new TestPerceptualHash()));
+            Assert.Equal("other IPerceptualHash must have Red, Green and Blue channel", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
### Description

:wave: 

Theses method doesn't use the result of `TryGetValue` and expect a non-null result:

https://github.com/dlemstra/Magick.NET/blob/d58472f4ad2157fd9a649dea7464370dee6621ea/src/Magick.NET/Statistics/Moments.cs#L39-L43

https://github.com/dlemstra/Magick.NET/blob/d58472f4ad2157fd9a649dea7464370dee6621ea/src/Magick.NET/Statistics/PerceptualHash.cs#L66-L70

This one can - explicitly - return a null value:

https://github.com/dlemstra/Magick.NET/blob/d58472f4ad2157fd9a649dea7464370dee6621ea/src/Magick.NET/Statistics/Statistics.cs#L35-L39

This PR:
- remove the `TryGetValue` for the first too method and use index access
- tests are added accordingly
- documentation is not (yet) updated (don't know if it's necessary)

If otherwise you prefer to not change the actual behavior (as it might be a breaking change, or just because the nullable returns is the wanted behavior), I will update the PR:
- add tests
- add nullable indicator to method return type

Regards.