### PR TITLE
doc: missing Exception for MagickImage.OilPaint

### DIFF
--- a/src/Magick.NET.Core/IMagickImage.cs
+++ b/src/Magick.NET.Core/IMagickImage.cs
@@ -2311,6 +2311,7 @@ public partial interface IMagickImage : IDisposable
     /// <summary>
     /// Oilpaint image (image looks like oil painting).
     /// </summary>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     void OilPaint();
 
     /// <summary>

--- a/src/Magick.NET/MagickImage.cs
+++ b/src/Magick.NET/MagickImage.cs
@@ -4335,6 +4335,7 @@ public sealed partial class MagickImage : IMagickImage<QuantumType>, INativeInst
     /// <summary>
     /// Oilpaint image (image looks like oil painting).
     /// </summary>
+    /// <exception cref="MagickException">Thrown when an error is raised by ImageMagick.</exception>
     public void OilPaint()
         => OilPaint(3.0, 1.0);
 


### PR DESCRIPTION
### Description

:wave: 

It's just a missing doc tag.

Regards.