### PR TITLE
Remove typo in *PerceptualHash summaries.

### DIFF
--- a/src/Magick.NET.Core/Statistics/IChannelPerceptualHash.cs
+++ b/src/Magick.NET.Core/Statistics/IChannelPerceptualHash.cs
@@ -6,7 +6,7 @@ using System;
 namespace ImageMagick;
 
 /// <summary>
-/// Contains the he perceptual hash of one image channel.
+/// Contains the perceptual hash of one image channel.
 /// </summary>
 public interface IChannelPerceptualHash
 {

--- a/src/Magick.NET.Core/Statistics/IPerceptualHash.cs
+++ b/src/Magick.NET.Core/Statistics/IPerceptualHash.cs
@@ -4,7 +4,7 @@
 namespace ImageMagick;
 
 /// <summary>
-/// Contains the he perceptual hash of one or more image channels.
+/// Contains the perceptual hash of one or more image channels.
 /// </summary>
 public interface IPerceptualHash
 {

--- a/src/Magick.NET/Statistics/ChannelPerceptualHash.cs
+++ b/src/Magick.NET/Statistics/ChannelPerceptualHash.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 namespace ImageMagick;
 
 /// <summary>
-/// Contains the he perceptual hash of one image channel.
+/// Contains the perceptual hash of one image channel.
 /// </summary>
 public partial class ChannelPerceptualHash : IChannelPerceptualHash
 {

--- a/src/Magick.NET/Statistics/PerceptualHash.cs
+++ b/src/Magick.NET/Statistics/PerceptualHash.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace ImageMagick;
 
 /// <summary>
-/// Contains the he perceptual hash of one or more image channels.
+/// Contains the perceptual hash of one or more image channels.
 /// </summary>
 public sealed partial class PerceptualHash : IPerceptualHash
 {


### PR DESCRIPTION
### Description

:wave:

Just a typo in `*PerceptualHash` classes summary.