### PR TITLE
fix: NativeDrawingWand.FillColor value can't be null

### DIFF
--- a/src/Magick.NET/Native/Drawables/DrawingWand.cs
+++ b/src/Magick.NET/Native/Drawables/DrawingWand.cs
@@ -81,7 +81,7 @@ internal partial class DrawingWand : IDisposable
 
         [Throws]
         [Instance(SetsInstance = false)]
-        public partial void FillColor(IMagickColor<QuantumType>? value);
+        public partial void FillColor(IMagickColor<QuantumType> value);
 
         [Throws]
         [Instance(SetsInstance = false)]


### PR DESCRIPTION
### Description

:wave: 

According to Magick.Native and ImageMagick sources, the parameter `value` of NativeDrawingWand.FillColor cannot be null:

https://github.com/dlemstra/Magick.Native/blob/6db05942001f01c3f344aa39064fb2d6413e0e46/src/Magick.Native/Drawables/DrawingWand.c#L151-L157

https://github.com/ImageMagick/ImageMagick/blob/0deac72ed480ac2ec8e9d766c15ddb3bca055952/MagickWand/drawing-wand.c#L4783-L4794