### PR TITLE
Fix typos in XML documentation comments

### DIFF
--- a/src/Magick.NET/Formats/Dds/DdsReadDefines.cs
+++ b/src/Magick.NET/Formats/Dds/DdsReadDefines.cs
@@ -17,7 +17,7 @@ public sealed class DdsReadDefines : IReadDefines
         => MagickFormat.Dds;
 
     /// <summary>
-    /// Gets or sets a value indicating wether mipmaps should be skipped (dds:skip-mipmaps).
+    /// Gets or sets a value indicating whether mipmaps should be skipped (dds:skip-mipmaps).
     /// </summary>
     public bool? SkipMipmaps { get; set; }
 

--- a/src/Magick.NET/Formats/Dng/DngReadDefines.cs
+++ b/src/Magick.NET/Formats/Dng/DngReadDefines.cs
@@ -11,7 +11,7 @@ namespace ImageMagick.Formats;
 public sealed class DngReadDefines : IReadDefines
 {
     /// <summary>
-    /// Gets or sets a value indicating wether auto brightness should be used (dng:no-auto-bright).
+    /// Gets or sets a value indicating whether auto brightness should be used (dng:no-auto-bright).
     /// </summary>
     public bool? DisableAutoBrightness { get; set; }
 
@@ -32,18 +32,18 @@ public sealed class DngReadDefines : IReadDefines
     public DngOutputColor? OutputColor { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether the embedded thumbnail should be read (dng:read-thumbnail). This profile can be
+    /// Gets or sets a value indicating whether the embedded thumbnail should be read (dng:read-thumbnail). This profile can be
     /// read by calling <see cref="IMagickImage.GetProfile(string)"/> with dng:thumbnail as the name of the profile.
     /// </summary>
     public bool? ReadThumbnail { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether auto whitebalance should be used (dng:use-auto-wb).
+    /// Gets or sets a value indicating whether auto white balance should be used (dng:use-auto-wb).
     /// </summary>
     public bool? UseAutoWhitebalance { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether the whitebalance of the camera should be used (dng:use-camera-wb).
+    /// Gets or sets a value indicating whether the white balance of the camera should be used (dng:use-camera-wb).
     /// </summary>
     public bool? UseCameraWhitebalance { get; set; }
 

--- a/src/Magick.NET/Formats/Pdf/PdfWriteDefines.cs
+++ b/src/Magick.NET/Formats/Pdf/PdfWriteDefines.cs
@@ -59,7 +59,7 @@ public sealed class PdfWriteDefines : IWriteDefines
     public string? Subject { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether a thumbnail should be added to the pdf document (pdf:thumbnail).
+    /// Gets or sets a value indicating whether a thumbnail should be added to the pdf document (pdf:thumbnail).
     /// </summary>
     public bool? Thumbnail { get; set; }
 

--- a/src/Magick.NET/Formats/WebP/WebPWriteDefines.cs
+++ b/src/Magick.NET/Formats/WebP/WebPWriteDefines.cs
@@ -27,17 +27,17 @@ public sealed class WebPWriteDefines : IWriteDefines
     public int? AlphaQuality { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether the algorithm should spend additional time optimizing the filtering strength to reach a well-balanced quality (webp:auto-filter).
+    /// Gets or sets a value indicating whether the algorithm should spend additional time optimizing the filtering strength to reach a well-balanced quality (webp:auto-filter).
     /// </summary>
     public bool? AutoFilter { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether a similar compression to that of JPEG but with less degradation should be used. (webp:emulate-jpeg-size).
+    /// Gets or sets a value indicating whether a similar compression to that of JPEG but with less degradation should be used. (webp:emulate-jpeg-size).
     /// </summary>
     public bool? EmulateJpegSize { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether RGB values should be preserved in transparent area. It's disabled by default to help compressibility.
+    /// Gets or sets a value indicating whether RGB values should be preserved in transparent area. It's disabled by default to help compressibility.
     /// </summary>
     public bool? Exact { get; set; }
 
@@ -68,12 +68,12 @@ public sealed class WebPWriteDefines : IWriteDefines
     public WebPImageHint? ImageHint { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether the image should be encoded without any loss (webp:lossless).
+    /// Gets or sets a value indicating whether the image should be encoded without any loss (webp:lossless).
     /// </summary>
     public bool? Lossless { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether the memory usage should be reduced (webp:low-memory).
+    /// Gets or sets a value indicating whether the memory usage should be reduced (webp:low-memory).
     /// </summary>
     public bool? LowMemory { get; set; }
 
@@ -114,7 +114,7 @@ public sealed class WebPWriteDefines : IWriteDefines
     public int? Segment { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether the compressed picture should be exported back (webp:show-compressed).
+    /// Gets or sets a value indicating whether the compressed picture should be exported back (webp:show-compressed).
     /// </summary>
     public bool? ShowCompressed { get; set; }
 
@@ -134,12 +134,12 @@ public sealed class WebPWriteDefines : IWriteDefines
     public int? TargetSize { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether multi-threaded encoding should be enabled (webp:thread-level).
+    /// Gets or sets a value indicating whether multi-threaded encoding should be enabled (webp:thread-level).
     /// </summary>
     public bool? ThreadLevel { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating wether sharp (and slow) RGB->YUV conversion should be used. (webp:use-sharp-yuv).
+    /// Gets or sets a value indicating whether sharp (and slow) RGB->YUV conversion should be used. (webp:use-sharp-yuv).
     /// </summary>
     public bool? UseSharpYuv { get; set; }
 


### PR DESCRIPTION
### Description

- changing 'wether' to 'whether'
- changing 'whitebalance' to 'white balance'

<!-- A description of the changes proposed in the pull-request -->

This pull request corrects some minor spelling mistakes in the XML documentation comments 

<!-- Thanks for contributing to Magick.NET! -->