### PR TITLE
Add PngWriteDefines to Magick.NET for PNG Chunk Management #225

### DIFF
--- a/src/Magick.NET/Formats/Png/PngChunkFlags.cs
+++ b/src/Magick.NET/Formats/Png/PngChunkFlags.cs
@@ -15,6 +15,11 @@ namespace ImageMagick.Formats
         None = 0,
 
         /// <summary>
+        /// Include or exclude all chunks.
+        /// </summary>
+        All = bKGD | cHRM | EXIF | gAMA | iCCP | iTXt | sRGB | tEXt | zCCP | zTXt | date,
+
+        /// <summary>
         /// Include or exclude bKGD chunk.
         /// </summary>
         bKGD = 1 << 0, // 0000 0001
@@ -67,6 +72,6 @@ namespace ImageMagick.Formats
         /// <summary>
         /// Include or exclude date chunk.
         /// </summary>
-        date = 1 << 10 // 100 0000 0000
+        date = 1 << 10, // 100 0000 0000
     }
 }

--- a/src/Magick.NET/Formats/Png/PngChunkFlags.cs
+++ b/src/Magick.NET/Formats/Png/PngChunkFlags.cs
@@ -1,0 +1,72 @@
+﻿using System;
+
+namespace ImageMagick.Formats
+{
+    /// <summary>
+    /// Specifies the chunks to be included or excluded in the PNG image.
+    /// This is a flags enumeration, allowing a bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    public enum PngChunkFlags
+    {
+        /// <summary>
+        /// No chunks specified.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Include or exclude bKGD chunk.
+        /// </summary>
+        bKGD = 1 << 0, // 0000 0001
+
+        /// <summary>
+        /// Include or exclude cHRM chunk.
+        /// </summary>
+        cHRM = 1 << 1, // 0000 0010
+
+        /// <summary>
+        /// Include or exclude EXIF chunk.
+        /// </summary>
+        EXIF = 1 << 2, // 0000 0100
+
+        /// <summary>
+        /// Include or exclude gAMA chunk.
+        /// </summary>
+        gAMA = 1 << 3, // 0000 1000
+
+        /// <summary>
+        /// Include or exclude iCCP chunk.
+        /// </summary>
+        iCCP = 1 << 4, // 0001 0000
+
+        /// <summary>
+        /// Include or exclude iTXt chunk.
+        /// </summary>
+        iTXt = 1 << 5, // 0010 0000
+
+        /// <summary>
+        /// Include or exclude sRGB chunk.
+        /// </summary>
+        sRGB = 1 << 6, // 0100 0000
+
+        /// <summary>
+        /// Include or exclude tEXt chunk.
+        /// </summary>
+        tEXt = 1 << 7, // 1000 0000
+
+        /// <summary>
+        /// Include or exclude zCCP chunk.
+        /// </summary>
+        zCCP = 1 << 8, // 1 0000 0000
+
+        /// <summary>
+        /// Include or exclude zTXt chunk.
+        /// </summary>
+        zTXt = 1 << 9, // 10 0000 0000
+
+        /// <summary>
+        /// Include or exclude date chunk.
+        /// </summary>
+        date = 1 << 10 // 100 0000 0000
+    }
+}

--- a/src/Magick.NET/Formats/Png/PngCompressionFilter.cs
+++ b/src/Magick.NET/Formats/Png/PngCompressionFilter.cs
@@ -1,0 +1,35 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+namespace ImageMagick.Formats;
+
+/// <summary>
+/// Specifies the PNG compression filter.
+/// </summary>
+public enum PngCompressionFilter
+{
+    /// <summary>
+    /// 0 - None: No filter.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Sub: Subtracts the value of the pixel to the left.
+    /// </summary>
+    Sub,
+
+    /// <summary>
+    /// Up: Subtracts the value of the pixel above.
+    /// </summary>
+    Up,
+
+    /// <summary>
+    /// Average: Uses the average of the left and above pixels.
+    /// </summary>
+    Average,
+
+    /// <summary>
+    /// Paeth: A predictive filter using the Paeth algorithm.
+    /// </summary>
+    Paeth,
+}

--- a/src/Magick.NET/Formats/Png/PngCompressionStrategy.cs
+++ b/src/Magick.NET/Formats/Png/PngCompressionStrategy.cs
@@ -1,0 +1,60 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+namespace ImageMagick.Formats;
+
+/// <summary>
+/// Specifies the PNG compression strategy.
+/// </summary>
+public enum PngCompressionStrategy
+{
+    /// <summary>
+    /// Use the Huffman compression.
+    /// </summary>
+    HuffmanOnly,
+
+    /// <summary>
+    /// Compression algorithm with filtering.
+    /// </summary>
+    Filtered,
+
+    /// <summary>
+    /// Use the Run-Length Encoding compression.
+    /// </summary>
+    RLE,
+
+    /// <summary>
+    /// Use a fixed strategy for compression.
+    /// </summary>
+    Fixed,
+
+    /// <summary>
+    /// Use the default compression strategy.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Adaptive filtering is used when quality is greater than 50 and the image does not have a color map; otherwise, no filtering is used.
+    /// </summary>
+    Adaptive,
+
+    /// <summary>
+    /// Adaptive filtering with minimum-sum-of-absolute-values is used.
+    /// </summary>
+    AdaptiveMinimumSum,
+
+    /// <summary>
+    /// LOCO color transformation (intrapixel differencing) and adaptive filtering with minimum-sum-of-absolute-values are used. Only applicable if the output is MNG.
+    /// </summary>
+    LOCO,
+
+    /// <summary>
+    /// The zlib Z_RLE compression strategy (or the Z_HUFFMAN_ONLY strategy when compression level is 0) is used with adaptive PNG filtering.
+    /// </summary>
+    ZRLEAdaptive,
+
+    /// <summary>
+    /// The zlib Z_RLE compression strategy (or the Z_HUFFMAN_ONLY strategy when compression level is 0) is used with no PNG filtering.
+    /// </summary>
+    ZRLENoFilter,
+}

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -59,6 +59,12 @@ public sealed class PngWriteDefines : IWriteDefines
     /// </summary>
     public bool PreserveiCCP { get; set; }
 
+
+    /// <summary>
+    /// Gets or sets the whether ColorMap should be preserve when writing the image.
+    /// </summary>
+    public bool PreserveColorMap { get; set; }
+
     /// <summary>
     /// Gets the format where the defines are for.
     /// </summary>
@@ -98,6 +104,9 @@ public sealed class PngWriteDefines : IWriteDefines
 
             if (PreserveiCCP)
                 yield return new MagickDefine(Format, "preserve-iCCP", PreserveiCCP);
+
+            if (PreserveColorMap)
+                yield return new MagickDefine(Format, "preserve-colormap", PreserveColorMap);
         }
     }
 }

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -1,0 +1,36 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+
+namespace ImageMagick.Formats;
+
+/// <summary>
+/// Class for defines that are used when a <see cref="MagickFormat.Png"/> image is written.
+/// </summary>
+public sealed class PngWriteDefines : IWriteDefines
+{
+    /// <summary>
+    /// Gets or sets the bit depth for the PNG image.
+    /// Valid values: 1, 2, 4, 8, 16.
+    /// </summary>
+    public uint? BitDepth { get; set; }
+
+    /// <summary>
+    /// Gets the format where the defines are for.
+    /// </summary>
+    public MagickFormat Format
+        => MagickFormat.Png;
+
+    /// <summary>
+    /// Gets the defines that should be set as a define on an image.
+    /// </summary>
+    public IEnumerable<IDefine> Defines
+    {
+        get
+        {
+            if (BitDepth.HasValue)
+                yield return new MagickDefine(Format, "bit-depth", BitDepth.Value);
+         }
+    }
+}

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -40,6 +40,11 @@ public sealed class PngWriteDefines : IWriteDefines
     public PngCompressionStrategy? CompressionStrategy { get; set; }
 
     /// <summary>
+    /// Gets or sets the chunks to be excluded.
+    /// </summary>
+    public PngChunkFlags? ExcludeChunks { get; set; }
+
+    /// <summary>
     /// Gets the format where the defines are for.
     /// </summary>
     public MagickFormat Format
@@ -66,6 +71,9 @@ public sealed class PngWriteDefines : IWriteDefines
 
             if (CompressionStrategy.HasValue)
                 yield return new MagickDefine(Format, "compression-strategy", CompressionStrategy.Value);
-         }
+
+            if (ExcludeChunks.HasValue)
+                yield return new MagickDefine(Format, "exclude-chunks", EnumHelper.ConvertFlags(ExcludeChunks.Value));
+        }
     }
 }

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -35,6 +35,11 @@ public sealed class PngWriteDefines : IWriteDefines
     public uint? CompressionLevel { get; set; }
 
     /// <summary>
+    /// Gets or sets the compression strategy for the PNG image.
+    /// </summary>
+    public PngCompressionStrategy? CompressionStrategy { get; set; }
+
+    /// <summary>
     /// Gets the format where the defines are for.
     /// </summary>
     public MagickFormat Format
@@ -58,6 +63,9 @@ public sealed class PngWriteDefines : IWriteDefines
 
             if (CompressionFilter.HasValue)
                 yield return new MagickDefine(Format, "compression-filter", CompressionFilter.Value);
+
+            if (CompressionStrategy.HasValue)
+                yield return new MagickDefine(Format, "compression-strategy", CompressionStrategy.Value);
          }
     }
 }

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -50,6 +50,11 @@ public sealed class PngWriteDefines : IWriteDefines
     public PngChunkFlags? IncludeChunks { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the PNG decoder should ignore the CRC when writing the image.
+    /// </summary>
+    public bool IgnoreCrc { get; set; }
+
+    /// <summary>
     /// Gets the format where the defines are for.
     /// </summary>
     public MagickFormat Format
@@ -82,6 +87,9 @@ public sealed class PngWriteDefines : IWriteDefines
 
             if (IncludeChunks.HasValue)
                 yield return new MagickDefine(Format, "include-chunks", EnumHelper.ConvertFlags(IncludeChunks.Value));
+
+            if (IgnoreCrc)
+                yield return new MagickDefine(Format, "ignore-crc", IgnoreCrc);
         }
     }
 }

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -22,6 +22,13 @@ public sealed class PngWriteDefines : IWriteDefines
     public ColorType? ColorType { get; set; }
 
     /// <summary>
+    /// Gets or sets the compression level for the PNG image.
+    /// The compression level ranges from 0 to 9, where 0 indicates no compression and 9 indicates maximum compression.
+    /// For compression level 0 (quality value less than 10), the Huffman-only strategy is used, which is the fastest but not necessarily the worst compression.
+    /// </summary>
+    public uint? CompressionLevel { get; set; }
+
+    /// <summary>
     /// Gets the format where the defines are for.
     /// </summary>
     public MagickFormat Format
@@ -39,6 +46,9 @@ public sealed class PngWriteDefines : IWriteDefines
 
             if (ColorType.HasValue)
                 yield return new MagickDefine(Format, "color-type", ColorType.Value);
+
+            if (CompressionLevel.HasValue)
+                yield return new MagickDefine(Format, "compression-level", CompressionLevel.Value);
          }
     }
 }

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -55,6 +55,11 @@ public sealed class PngWriteDefines : IWriteDefines
     public bool IgnoreCrc { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the iCCP chunk should be preserved when writing the image.
+    /// </summary>
+    public bool PreserveiCCP { get; set; }
+
+    /// <summary>
     /// Gets the format where the defines are for.
     /// </summary>
     public MagickFormat Format
@@ -90,6 +95,9 @@ public sealed class PngWriteDefines : IWriteDefines
 
             if (IgnoreCrc)
                 yield return new MagickDefine(Format, "ignore-crc", IgnoreCrc);
+
+            if (PreserveiCCP)
+                yield return new MagickDefine(Format, "preserve-iCCP", PreserveiCCP);
         }
     }
 }

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -22,6 +22,12 @@ public sealed class PngWriteDefines : IWriteDefines
     public ColorType? ColorType { get; set; }
 
     /// <summary>
+    /// Gets or sets the compression filter for the PNG image.
+    /// For compression level 0 (quality value less than 10), the Huffman-only strategy is used, which is fastest but not necessarily the worst compression.
+    /// </summary>
+    public PngCompressionFilter? CompressionFilter { get; set; }
+
+    /// <summary>
     /// Gets or sets the compression level for the PNG image.
     /// The compression level ranges from 0 to 9, where 0 indicates no compression and 9 indicates maximum compression.
     /// For compression level 0 (quality value less than 10), the Huffman-only strategy is used, which is the fastest but not necessarily the worst compression.
@@ -49,6 +55,9 @@ public sealed class PngWriteDefines : IWriteDefines
 
             if (CompressionLevel.HasValue)
                 yield return new MagickDefine(Format, "compression-level", CompressionLevel.Value);
+
+            if (CompressionFilter.HasValue)
+                yield return new MagickDefine(Format, "compression-filter", CompressionFilter.Value);
          }
     }
 }

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -17,6 +17,11 @@ public sealed class PngWriteDefines : IWriteDefines
     public uint? BitDepth { get; set; }
 
     /// <summary>
+    /// Gets or sets the color type of the image.
+    /// </summary>
+    public ColorType? ColorType { get; set; }
+
+    /// <summary>
     /// Gets the format where the defines are for.
     /// </summary>
     public MagickFormat Format
@@ -31,6 +36,9 @@ public sealed class PngWriteDefines : IWriteDefines
         {
             if (BitDepth.HasValue)
                 yield return new MagickDefine(Format, "bit-depth", BitDepth.Value);
+
+            if (ColorType.HasValue)
+                yield return new MagickDefine(Format, "color-type", ColorType.Value);
          }
     }
 }

--- a/src/Magick.NET/Formats/Png/PngWriteDefines.cs
+++ b/src/Magick.NET/Formats/Png/PngWriteDefines.cs
@@ -45,6 +45,11 @@ public sealed class PngWriteDefines : IWriteDefines
     public PngChunkFlags? ExcludeChunks { get; set; }
 
     /// <summary>
+    /// Gets or sets the chunks to be included.
+    /// </summary>
+    public PngChunkFlags? IncludeChunks { get; set; }
+
+    /// <summary>
     /// Gets the format where the defines are for.
     /// </summary>
     public MagickFormat Format
@@ -74,6 +79,9 @@ public sealed class PngWriteDefines : IWriteDefines
 
             if (ExcludeChunks.HasValue)
                 yield return new MagickDefine(Format, "exclude-chunks", EnumHelper.ConvertFlags(ExcludeChunks.Value));
+
+            if (IncludeChunks.HasValue)
+                yield return new MagickDefine(Format, "include-chunks", EnumHelper.ConvertFlags(IncludeChunks.Value));
         }
     }
 }

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheBitDepthProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheBitDepthProperty.cs
@@ -1,0 +1,38 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class TheBitDepthProperty
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                BitDepth = 8u,
+            });
+
+            Assert.Equal("8", image.Settings.GetDefine(MagickFormat.Png, "bit-depth"));
+        }
+
+        [Fact]
+        public void ShouldSetTheDefineNull()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                BitDepth = null,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "bit-depth"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheColorTypeProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheColorTypeProperty.cs
@@ -1,0 +1,37 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class TheColorTypeProperty
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                ColorType = ColorType.Grayscale,
+            });
+            Assert.Equal("grayscale", image.Settings.GetDefine(MagickFormat.Png, "color-type"));
+        }
+
+        [Fact]
+        public void ShouldSetTheDefineNull()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                ColorType = null,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "color-type"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheCompressionFilterProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheCompressionFilterProperty.cs
@@ -1,0 +1,38 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class TheCompressionFilterProperty
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                CompressionFilter = PngCompressionFilter.Paeth,
+            });
+
+            Assert.Equal("paeth", image.Settings.GetDefine(MagickFormat.Png, "compression-filter"));
+        }
+
+        [Fact]
+        public void ShouldSetTheDefineNull()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                CompressionFilter = null,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "compression-filter"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheCompressionLevelProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheCompressionLevelProperty.cs
@@ -1,0 +1,38 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class TheCompressionLevelProperty
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                CompressionLevel = 5,
+            });
+
+            Assert.Equal("5", image.Settings.GetDefine(MagickFormat.Png, "compression-level"));
+        }
+
+        [Fact]
+        public void ShouldSetTheDefineNull()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                CompressionLevel = null,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "compression-level"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheExcludeChunksProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheExcludeChunksProperty.cs
@@ -1,0 +1,50 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class TheExcludeChunksProperty
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                ExcludeChunks = PngChunkFlags.bKGD | PngChunkFlags.iCCP,
+            });
+
+            Assert.Equal("bKGD, iCCP", image.Settings.GetDefine(MagickFormat.Png, "exclude-chunks"));
+        }
+
+        [Fact]
+        public void ShouldSetTheDefineNull()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                ExcludeChunks = null,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "exclude-chunks"));
+        }
+
+        [Fact]
+        public void ShouldSetTheDefineToNone()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                ExcludeChunks = PngChunkFlags.None,
+            });
+
+            Assert.Equal("None", image.Settings.GetDefine(MagickFormat.Png, "exclude-chunks"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheIgnoreCrcProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheIgnoreCrcProperty.cs
@@ -1,0 +1,38 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class TheIgnoreCrcProperty
+    {
+        [Fact]
+        public void ShouldSetTheDefineWhenSetToTrue()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                IgnoreCrc = true,
+            });
+
+            Assert.Equal("true", image.Settings.GetDefine(MagickFormat.Png, "ignore-crc"));
+        }
+
+        [Fact]
+        public void ShouldNotSetTheDefineWhenSetToFalse()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                IgnoreCrc = false,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "ignore-crc"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheIncludeChunksProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/TheIncludeChunksProperty.cs
@@ -1,0 +1,38 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class TheIncludeChunksProperty
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                IncludeChunks = PngChunkFlags.iTXt | PngChunkFlags.tEXt,
+            });
+
+            Assert.Equal("iTXt, tEXt", image.Settings.GetDefine(MagickFormat.Png, "include-chunks"));
+        }
+
+        [Fact]
+        public void ShouldSetTheDefineNull()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                IncludeChunks = null,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "include-chunks"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/ThePreserveColorMapPropety.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/ThePreserveColorMapPropety.cs
@@ -1,0 +1,38 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class ThePreserveColorMapPropety
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                PreserveColorMap = true,
+            });
+
+            Assert.Equal("true", image.Settings.GetDefine(MagickFormat.Png, "preserve-colormap"));
+        }
+
+        [Fact]
+        public void ShouldNotSetTheDefineWhenSetToFalse()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                PreserveColorMap = false,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "preserve-colormap"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/ThePreserveiCCPProperty.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/ThePreserveiCCPProperty.cs
@@ -1,0 +1,38 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class ThePreserveiCCPProperty
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                PreserveiCCP = true,
+            });
+
+            Assert.Equal("true", image.Settings.GetDefine(MagickFormat.Png, "preserve-iCCP"));
+        }
+
+        [Fact]
+        public void ShouldNotSetTheDefineWhenSetToFalse()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                PreserveiCCP = false,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "preserve-iCCP"));
+        }
+    }
+}

--- a/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/ThreCompressionStrategy.cs
+++ b/tests/Magick.NET.Tests/Formats/Png/PngWriteDefinesTests/ThreCompressionStrategy.cs
@@ -1,0 +1,38 @@
+﻿// Copyright Dirk Lemstra https://github.com/dlemstra/Magick.NET.
+// Licensed under the Apache License, Version 2.0.
+
+using ImageMagick;
+using ImageMagick.Formats;
+using Xunit;
+
+namespace Magick.NET.Tests;
+
+public partial class PngWriteDefinesTests
+{
+    public class ThreCompressionStrategy
+    {
+        [Fact]
+        public void ShouldSetTheDefine()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                CompressionStrategy = PngCompressionStrategy.HuffmanOnly,
+            });
+
+            Assert.Equal("huffmanonly", image.Settings.GetDefine(MagickFormat.Png, "compression-strategy"));
+        }
+
+        [Fact]
+        public void ShouldSetTheDefineNull()
+        {
+            using var image = new MagickImage();
+            image.Settings.SetDefines(new PngWriteDefines
+            {
+                CompressionStrategy = null,
+            });
+
+            Assert.Null(image.Settings.GetDefine(MagickFormat.Png, "compression-strategy"));
+        }
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the PngWriteDefines class to the Magick.NET project. The PngWriteDefines class includes several enums (PngChunkFlags, PngCompressionFilter, PngCompressionStrategy),

<!-- A description of the changes proposed in the pull-request -->

Changes Proposed:

Added the PngWriteDefines class with the following properties:

BitDepth - Specifies the bit depth for the PNG image.
ColorType - Specifies the color type for the PNG image.
CompressionFilter - Specifies the compression filter for the PNG image using the PngCompressionFilter enum.
CompressionLevel - Specifies the compression level for the PNG image.
CompressionStrategy - Specifies the compression strategy for the PNG image using the PngCompressionStrategy enum.
ExcludeChunks - Specifies the chunks to be excluded using the PngChunkFlags enum.
IncludeChunks - Specifies the chunks to be included using the PngChunkFlags enum.
IgnoreCrc - Indicates whether the PNG decoder should ignore the CRC.
PreserveICCP - Indicates whether to preserve the ICC profile.
PreserveColormap - Indicates whether to preserve the colormap.

<!-- Thanks for contributing to Magick.NET! -->