### PR TITLE
Fix ImageFormat equality comparison

### DIFF
--- a/src/Magick.NET.SystemDrawing/ImageFormatExtensions.cs
+++ b/src/Magick.NET.SystemDrawing/ImageFormatExtensions.cs
@@ -10,19 +10,19 @@ internal static class ImageFormatExtensions
 {
     public static MagickFormat ToFormat(this ImageFormat self)
     {
-        if (self == ImageFormat.Bmp || self == ImageFormat.MemoryBmp)
+        if (self.Guid == ImageFormat.Bmp.Guid || self.Guid == ImageFormat.MemoryBmp.Guid)
             return MagickFormat.Bmp;
-        else if (self == ImageFormat.Gif)
+        else if (self.Guid == ImageFormat.Gif.Guid)
             return MagickFormat.Gif;
-        else if (self == ImageFormat.Icon)
+        else if (self.Guid == ImageFormat.Icon.Guid)
             return MagickFormat.Icon;
-        else if (self == ImageFormat.Jpeg)
+        else if (self.Guid == ImageFormat.Jpeg.Guid)
             return MagickFormat.Jpeg;
-        else if (self == ImageFormat.Png)
+        else if (self.Guid == ImageFormat.Png.Guid)
             return MagickFormat.Png;
-        else if (self == ImageFormat.Tiff)
+        else if (self.Guid == ImageFormat.Tiff.Guid)
             return MagickFormat.Tiff;
         else
-            throw new NotSupportedException("Unsupported image format: " + self.ToString());
+            throw new NotSupportedException($"Unsupported image format: {self}");
     }
 }


### PR DESCRIPTION
When working with serialized images, e.g. embedded resources in WinForms, the equality check of the extension method fails. When deserializing the image, a new instance of `ImageFormat` is created, which still uses the same `Guid` as the singleton instance, but represents a whole new instance, thus failing the equality check.