### PR TITLE
Added double backslashes inside file name

### DIFF
--- a/docs/LosslessCompression.md
+++ b/docs/LosslessCompression.md
@@ -3,7 +3,7 @@
 ## Lossless compress JPEG logo
 
 ```C#
-var snakewareLogo = new FileInfo("c:\path\to\Snakeware.jpg");
+var snakewareLogo = new FileInfo("c:\\path\\to\\Snakeware.jpg");
 
 Console.WriteLine("Bytes before: " + snakewareLogo.Length);
 

--- a/docs/LosslessCompression.md
+++ b/docs/LosslessCompression.md
@@ -3,7 +3,7 @@
 ## Lossless compress JPEG logo
 
 ```C#
-var snakewareLogo = new FileInfo("c:\\path\\to\\Snakeware.jpg");
+var snakewareLogo = new FileInfo(@"c:\path\to\Snakeware.jpg");
 
 Console.WriteLine("Bytes before: " + snakewareLogo.Length);
 


### PR DESCRIPTION
### Description

Example for lossless image compression contains a single `\` character as path separator which is an escape character in C#. Double backslash `\\` should be used instead.

Before:
```cs
var snakewareLogo = new FileInfo("c:\path\to\Snakeware.jpg");
```

After:
```cs
var snakewareLogo = new FileInfo("c:\\path\\to\\Snakeware.jpg");
```