### PR TITLE
Fixed cancelled ReadAsync/WriteAsync throwing the exception of the native operation instead of an OperationCanceledException

### DIFF
--- a/src/Magick.NET/Helpers/AsyncStreamWrapper.cs
+++ b/src/Magick.NET/Helpers/AsyncStreamWrapper.cs
@@ -59,7 +59,18 @@ internal class AsyncStreamWrapper : StreamWrapperBase
             TaskScheduler.Default);
         var readTask = ReadAsync(cancellationToken);
 
-        await Task.WhenAll(actionTask, readTask).ConfigureAwait(false);
+        try
+        {
+            await Task.WhenAll(actionTask, readTask).ConfigureAwait(false);
+        }
+        catch when (_exceptionThrown)
+        {
+            // The native operation failed because a stream operation failed. When that failure was
+            // caused by a cancellation the exception of the native operation (e.g. a corrupt image
+            // exception from the coder) should be replaced with an OperationCanceledException.
+            cancellationToken.ThrowIfCancellationRequested();
+            throw;
+        }
 
         if (_exceptionThrown)
             cancellationToken.ThrowIfCancellationRequested();
@@ -88,7 +99,19 @@ internal class AsyncStreamWrapper : StreamWrapperBase
         var readTask = ReadAsync(cancellationToken);
         var writeTask = WriteAsync(cancellationToken);
 
-        await Task.WhenAll(actionTask, readTask, writeTask).ConfigureAwait(false);
+        try
+        {
+            await Task.WhenAll(actionTask, readTask, writeTask).ConfigureAwait(false);
+        }
+        catch when (_exceptionThrown)
+        {
+            // The native operation failed because a stream operation failed. When that failure was
+            // caused by a cancellation the exception of the native operation (e.g. "Output file
+            // write error --- out of disk space?" from the jpeg coder) should be replaced with
+            // an OperationCanceledException.
+            cancellationToken.ThrowIfCancellationRequested();
+            throw;
+        }
 
         if (_exceptionThrown)
             cancellationToken.ThrowIfCancellationRequested();

--- a/tests/Magick.NET.Tests/Helpers/AsyncStreamWrapperTest/TheReadAsyncMethod.cs
+++ b/tests/Magick.NET.Tests/Helpers/AsyncStreamWrapperTest/TheReadAsyncMethod.cs
@@ -116,5 +116,28 @@ public partial class AsyncStreamWrapperTest
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => wrapper.ReadAsync(ReadSync, cancellationTokenSource.Token));
         }
+
+        [Fact]
+        public async Task ShouldThrowExceptionWhenOperationIsCancelledAndActionThrowsException()
+        {
+            using var stream = new MemoryStream();
+            using var wrapper = AsyncStreamWrapper.CreateForReading(stream);
+
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            unsafe void ReadSync()
+            {
+                var buffer = new byte[10];
+                fixed (byte* p = buffer)
+                {
+                    var count = wrapper.Read((IntPtr)p, (UIntPtr)10, IntPtr.Zero);
+                    if (count == -1)
+                        throw new InvalidOperationException("Simulates the exception the native code throws when a read fails (e.g. a corrupt image exception).");
+                }
+            }
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => wrapper.ReadAsync(ReadSync, cancellationTokenSource.Token));
+        }
     }
 }

--- a/tests/Magick.NET.Tests/Helpers/AsyncStreamWrapperTest/TheWriteAsyncMethod.cs
+++ b/tests/Magick.NET.Tests/Helpers/AsyncStreamWrapperTest/TheWriteAsyncMethod.cs
@@ -113,5 +113,28 @@ public partial class AsyncStreamWrapperTest
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => wrapper.WriteAsync(WriteSync, cancellationTokenSource.Token));
         }
+
+        [Fact]
+        public async Task ShouldThrowExceptionWhenOperationIsCancelledAndActionThrowsException()
+        {
+            using var stream = new MemoryStream();
+            using var wrapper = AsyncStreamWrapper.CreateForWriting(stream);
+
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            unsafe void WriteSync()
+            {
+                var buffer = new byte[5];
+                fixed (byte* p = buffer)
+                {
+                    var count = wrapper.Write((IntPtr)p, (UIntPtr)5, IntPtr.Zero);
+                    if (count == -1)
+                        throw new InvalidOperationException("Simulates the exception the native code throws when a write fails (e.g. the jpeg coder).");
+                }
+            }
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => wrapper.WriteAsync(WriteSync, cancellationTokenSource.Token));
+        }
     }
 }

--- a/tests/Magick.NET.Tests/MagickImageTests/TheReadAsyncMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheReadAsyncMethod.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ImageMagick;
 using Xunit;
@@ -196,6 +197,17 @@ public partial class MagickImageTests
                 using var image = new MagickImage();
 
                 await Assert.ThrowsAsync<ArgumentNullException>("stream", () => image.ReadAsync((Stream)null!, TestContext.Current.CancellationToken));
+            }
+
+            [Fact]
+            public async Task ShouldThrowOperationCanceledExceptionWhenOperationIsCancelled()
+            {
+                using var image = new MagickImage();
+                using var stream = File.OpenRead(Files.ImageMagickJPG);
+                using var cancellationTokenSource = new CancellationTokenSource();
+                cancellationTokenSource.Cancel();
+
+                await Assert.ThrowsAsync<OperationCanceledException>(() => image.ReadAsync(stream, cancellationTokenSource.Token));
             }
 
             [Fact]

--- a/tests/Magick.NET.Tests/MagickImageTests/TheWriteAsyncMethod.cs
+++ b/tests/Magick.NET.Tests/MagickImageTests/TheWriteAsyncMethod.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using ImageMagick;
 using ImageMagick.Formats;
@@ -224,6 +225,19 @@ public partial class MagickImageTests
                 using var image = new MagickImage();
 
                 await Assert.ThrowsAsync<ArgumentNullException>("stream", () => image.WriteAsync((Stream)null!, TestContext.Current.CancellationToken));
+            }
+
+            [Fact]
+            public async Task ShouldThrowOperationCanceledExceptionWhenOperationIsCancelled()
+            {
+                using var image = new MagickImage(MagickColors.Red, 100, 100);
+                image.Format = MagickFormat.Jpeg;
+
+                using var stream = new MemoryStream();
+                using var cancellationTokenSource = new CancellationTokenSource();
+                cancellationTokenSource.Cancel();
+
+                await Assert.ThrowsAsync<OperationCanceledException>(() => image.WriteAsync(stream, cancellationTokenSource.Token));
             }
         }
 


### PR DESCRIPTION
### Description

Fixes #2066.

Since 14.15.0 (when the `AsyncStreamWrapper` was introduced), cancelling `ReadAsync`/`WriteAsync` stream operations throws the exception of the native operation instead of an `OperationCanceledException`. For a cancelled JPEG write that is:

```
ImageMagick.MagickCorruptImageErrorException: Output file write error --- out of disk space? `' @ error/jpeg.c/JPEGErrorHandler/614
```

The cause: when the token is cancelled, the async pump loops set `_exceptionThrown` and the blocked native callback reports a failed read/write, which makes the native coder raise an error that propagates out of the action task. The existing conversion at the end of `ReadAsync(Action, ...)`/`WriteAsync(Action, ...)`:

```csharp
if (_exceptionThrown)
    cancellationToken.ThrowIfCancellationRequested();
```

is unreachable in that case because `await Task.WhenAll(...)` rethrows the action task's exception first.

This change wraps the `Task.WhenAll` in a `try/catch when (_exceptionThrown)` that calls `ThrowIfCancellationRequested()` (and rethrows the original exception when the failure was not caused by a cancellation, preserving the current behavior for stream exceptions).

The existing cancellation tests did not catch this because their test actions ignore the failed read/write result; the native coders throw in that situation. The new tests mirror the existing ones but throw from the action when the operation fails, plus end-to-end tests on `MagickImage.ReadAsync(Stream)`/`WriteAsync(Stream)` with a cancelled token.

Verified with the Q8 x64 net8.0 test suite on Windows: all tests pass with the fix; the four new tests fail without it (they reproduce the exact exceptions from #2066).
